### PR TITLE
Support for string output templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 ### New
 
 - Support for output formats JSON and EDN
-- Support for output template when format is string 
+- Support for output template when format is string
+- Support for custom highlighting tags
 - Validation of the CLI options
 - Building an uberjar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Support for custom highlighting tags
 - Validation of the CLI options
 - Building an uberjar
+- Scoring (disables highlighting and tags)
 
 ## v2021.01.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ### New
 
 - Support for output formats JSON and EDN
+- Support for output template when format is string 
 - Validation of the CLI options
 - Building an uberjar
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Grep-like utility based on [Lucene Monitor](https://lucene.apache.org/core/8_7_0
 - Output can be formatted as JSON of EDN
 - Text output is colored or separated with customizable tags
 - Text output supports templates
+- Scoring mode (disables highlighting for now)
 - Supports [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)) as text input
 - Supports [GLOB](https://en.wikipedia.org/wiki/Glob_(programming)) [file pattern](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
 - Compiled with [GraalVM native-image](https://www.graalvm.org/reference-manual/native-image/) tool
@@ -224,6 +225,14 @@ echo "some text to to match" | clojure -M -m lmgrep.core "text" --pre-tags="<em>
 =>
 some <em>text</em> to to match
 ```
+
+## Scoring
+
+The main thing to understand is that scoring if for every line separately in the context of that one line as a whole corpus.
+
+Another consideration is that scoring in summed up for every line of all the matches. E.g. query "one two" is rewritten by Lucene into two term queries.
+
+Each individual score is BM25 which is default in Lucene.
 
 ## Future work
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Grep-like utility based on [Lucene Monitor](https://lucene.apache.org/core/8_7_0
 - Supports Lucene query syntax as described [here](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html)
 - Supports various text tokenizers
 - Supports various term stemmers for multiple languages
-- Text output is colored
 - Output can be formatted as JSON of EDN
+- Text output is colored
+- Text output supports templates
 - Supports [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)) as text input
 - Supports [GLOB](https://en.wikipedia.org/wiki/Glob_(programming)) [file pattern](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
 - Compiled with [GraalVM native-image](https://www.graalvm.org/reference-manual/native-image/) tool
@@ -48,7 +49,7 @@ Example of the `lmgrep`:
 ./deps.edn:28:  {:main-opts  ["-m clj.native-image core"
 ```
 
-The output is somewhat similar to `grep`, example:
+The default output is somewhat similar to `grep`, example:
 ```shell
 grep -n -R --include=\*.{edn,clj} "main" ./
 =>
@@ -203,6 +204,19 @@ Lint the core with clj-kondo:
 ```shell
 make lint
 ```
+
+## Print results with a custom format
+
+```shell
+./lmgrep --template="FILE={{file}} LINE_NR={{line-number}} LINE={{highlighted-line}}" "test" "**.md"
+```
+
+| Template Variable     | Notes                                                     |
+|-----------------------|-----------------------------------------------------------|
+| `{{file}}`            | File name                                                 |
+| `{{line-number}}`     | Line number where the text matched the query              |
+| `{{highlighted-line}}`| Line that matched the query with highlighters applied     |
+| `{{line}}`            | Line that matched the query                               |
 
 ## Future work
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ make lint
 | `{{line-number}}`     | Line number where the text matched the query              |
 | `{{highlighted-line}}`| Line that matched the query with highlighters applied     |
 | `{{line}}`            | Line that matched the query                               |
+| `{{score}}`           | Score of the match (summed)                               |
 
 When `{{highlighted-line}}` is used then `--pre-tags` and `--post-tags` options are available, e.g.:
 ```shell
@@ -228,9 +229,9 @@ some <em>text</em> to to match
 
 ## Scoring
 
-The main thing to understand is that scoring if for every line separately in the context of that one line as a whole corpus.
+The main thing to understand is that scoring is for every line separately in the context of that one line as a whole corpus.
 
-Another consideration is that scoring in summed up for every line of all the matches. E.g. query "one two" is rewritten by Lucene into two term queries.
+Another consideration is that scoring is summed up for every line of all the matches. E.g. query "one two" is rewritten by Lucene into two term queries.
 
 Each individual score is BM25 which is default in Lucene.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Grep-like utility based on [Lucene Monitor](https://lucene.apache.org/core/8_7_0
 - Supports various text tokenizers
 - Supports various term stemmers for multiple languages
 - Output can be formatted as JSON of EDN
-- Text output is colored
+- Text output is colored or separated with customizable tags
 - Text output supports templates
 - Supports [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)) as text input
 - Supports [GLOB](https://en.wikipedia.org/wiki/Glob_(programming)) [file pattern](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
@@ -218,13 +218,18 @@ make lint
 | `{{highlighted-line}}`| Line that matched the query with highlighters applied     |
 | `{{line}}`            | Line that matched the query                               |
 
+When `{{highlighted-line}}` is used then `--pre-tags` and `--post-tags` options are available, e.g.:
+```shell
+echo "some text to to match" | clojure -M -m lmgrep.core "text" --pre-tags="<em>" --post-tags="</em>" --template="{{highlighted-line}}"
+=>
+some <em>text</em> to to match
+```
+
 ## Future work
 
-- [ ] Automate builds for [multiple platforms](https://github.com/dainiusjocas/lucene-grep/issues/9)
-- [ ] Optimize highlighting of [multiple lines in batches](https://github.com/dainiusjocas/lucene-grep/issues/3)
+- [ ] Optimize matching by [processing lines in batches](https://github.com/dainiusjocas/lucene-grep/issues/3)
 - [ ] Exclude files with [GLOB](https://github.com/dainiusjocas/lucene-grep/issues/5)
-- [ ] Support other [output formats](https://github.com/dainiusjocas/lucene-grep/issues/8)
-- [ ] [Custom coloring](https://github.com/dainiusjocas/lucene-grep/issues/7) would be nice
+- [ ] Automate builds for [multiple platforms](https://github.com/dainiusjocas/lucene-grep/issues/9)
 
 ## License
 

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -39,7 +39,7 @@
 (def cli-options
   [[nil "--tokenizer TOKENIZER" (str "Tokenizer to use, one of: " (options-to-str tokenizers))
     :parse-fn #(keyword (str/lower-case %))
-    :validate [#(contains? format-options %) (str "Tokenizer must be one of: " (options-to-str tokenizers))]]
+    :validate [#(contains? tokenizers %) (str "Tokenizer must be one of: " (options-to-str tokenizers))]]
    [nil "--case-sensitive? CASE_SENSITIVE" "If text should be case sensitive"
     :parse-fn #(Boolean/parseBoolean %)
     :default false]
@@ -51,7 +51,8 @@
     :default true]
    [nil "--stemmer STEMMER" (str "Which stemmer to use for token stemming, one of: " (options-to-str stemmers))
     :parse-fn #(keyword (str/lower-case %))
-    :validate [#(contains? format-options %) (str "Stemmer must be one of: " (options-to-str stemmers))]]
+    :validate [#(contains? stemmers %) (str "Stemmer must be one of: " (options-to-str stemmers))]]
+   [nil "--with-score" "If the matching score should be computed"]
    [nil "--format FORMAT" (str "How the output should be formatted, one of: " (options-to-str format-options))
     :parse-fn #(keyword (str/lower-case %))
     :validate [#(contains? format-options %) (str "Format must be one of: " (options-to-str format-options))]]
@@ -72,4 +73,5 @@
 (comment
   (lmgrep.cli/handle-args ["--tokenizer=standard" "--stem?=false" "--stemmer=english" "--case-sensitive?=true"])
   (lmgrep.cli/handle-args ["test"])
-  (lmgrep.cli/handle-args ["--format=edn"]))
+  (lmgrep.cli/handle-args ["--format=edn"])
+  (lmgrep.cli/handle-args ["--with-score"]))

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -56,6 +56,8 @@
     :parse-fn #(keyword (str/lower-case %))
     :validate [#(contains? format-options %) (str "Format must be one of: " (options-to-str format-options))]]
    [nil "--template TEMPLATE" "The template for the output string, e.g.: file={{file}} line-number={{line-number}} line={{line}}"]
+   [nil "--pre-tags PRE_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --post-tags"]
+   [nil "--post-tags POST_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --pre-tags"]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)
    ; :default 0]

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -55,6 +55,7 @@
    [nil "--format FORMAT" (str "How the output should be formatted, one of: " (options-to-str format-options))
     :parse-fn #(keyword (str/lower-case %))
     :validate [#(contains? format-options %) (str "Format must be one of: " (options-to-str format-options))]]
+   [nil "--template TEMPLATE" "The template for the output string, e.g.: file={{file}} line-number={{line-number}} line={{line}}"]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)
    ; :default 0]

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -18,49 +18,65 @@
 (defn highlight-line
   "TODO: overlapping phrase highlights are combined under one color, maybe solve it?"
   [line-str highlights options]
-  (when (seq highlights)
-    (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
-                         #(str (:pre-tags options) % (:post-tags options))
-                         red-text)]
-      (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
-             acc ""
-             last-position 0]
-        (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
-              highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
-                          (if (< (:begin-offset ann) last-position)
-                            ; adjusting highlight text for overlap
-                            (highlight-fn (subs text-to-highlight (- last-position (:begin-offset ann))))
-                            (highlight-fn text-to-highlight)))
-              suffix (if (nil? next-ann)
-                       (subs line-str (:end-offset ann))
-                       (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
-                                                             (:end-offset ann))))]
-          (if (nil? next-ann)
-            (str acc prefix highlight suffix)
-            (recur ann-pairs
-                   (str acc prefix highlight suffix)
-                   (long (max (:begin-offset next-ann)
-                              (:end-offset ann))))))))))
+  (if (:with-score options)
+    line-str
+    (when (seq highlights)
+      (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                           #(str (:pre-tags options) % (:post-tags options))
+                           red-text)]
+        (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
+               acc ""
+               last-position 0]
+          (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
+                highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
+                            (if (< (:begin-offset ann) last-position)
+                              ; adjusting highlight text for overlap
+                              (highlight-fn (subs text-to-highlight (- last-position (:begin-offset ann))))
+                              (highlight-fn text-to-highlight)))
+                suffix (if (nil? next-ann)
+                         (subs line-str (:end-offset ann))
+                         (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
+                                                               (:end-offset ann))))]
+            (if (nil? next-ann)
+              (str acc prefix highlight suffix)
+              (recur ann-pairs
+                     (str acc prefix highlight suffix)
+                     (long (max (:begin-offset next-ann)
+                                (:end-offset ann)))))))))))
 
-(defn string-output [highlights {:keys [file line-number line]} options]
+(defn string-output [highlights {:keys [file line-number line score]} options]
   (if-let [template (:template options)]
     (-> template
         (str/replace "{{file}}" (or file ""))
         (str/replace "{{line-number}}" (str line-number))
         (str/replace "{{highlighted-line}}" (highlight-line line highlights options))
-        (str/replace "{{line}}" line))
-    (format "%s:%s:%s"
-            (purple-text (or file "*STDIN*"))
-            (green-text line-number)
-            (highlight-line line highlights options))))
+        (str/replace "{{line}}" line)
+        (str/replace "{{score}}" (str score)))
+    (if score
+      (format "%s:%s:%s:%s"
+              (purple-text (or file "*STDIN*"))
+              (green-text line-number)
+              (purple-text score)
+              (highlight-line line highlights options))
+      (format "%s:%s:%s"
+              (purple-text (or file "*STDIN*"))
+              (green-text line-number)
+              (highlight-line line highlights options)))))
+
+(defn compact [m] (into {} (remove (comp nil? second) m)))
+
+(defn sum-score [highlights]
+  (when-let [scores (seq (remove nil? (map :score highlights)))]
+    (reduce + scores)))
 
 (defn match-lines [highlighter-fn file-path lines options]
   (doseq [[line-str line-number] (map (fn [line-str line-number] [line-str line-number])
                                       lines (range))]
-    (when-let [highlights (seq (highlighter-fn line-str))]
-      (let [details {:file        file-path
-                     :line-number (inc line-number)
-                     :line        line-str}]
+    (when-let [highlights (seq (highlighter-fn line-str (select-keys options [:with-score])))]
+      (let [details (compact {:file        file-path
+                              :line-number (inc line-number)
+                              :line        line-str
+                              :score       (sum-score highlights)})]
         (println (case (:format options)
                    :edn (pr-str details)
                    :json (json/write-value-as-string details)

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -9,4 +9,4 @@
           highlighter-fn (phrases/highlighter [{:text query-string}])
           text "prefix text suffix"]
       (is (= (str "prefix " \ "[1;31mtext" \ "[0m suffix")
-             (grep/highlight-line text (highlighter-fn text)))))))
+             (grep/highlight-line text (highlighter-fn text) {}))))))


### PR DESCRIPTION
With several supported variables templates as such can be specified.
```
./lmgrep --template="FILE={{file}} LINE_NR={{line-number}} LINE={{highlighted-line}}" "test" "**.md"
```

closes #17  #8 