### PR TITLE
Excludes file matcher GLOB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Validation of the CLI options
 - Building an uberjar
 - Scoring (disables highlighting and tags)
+- Exclude files with GLOB
 
 ## v2021.01.13
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Grep-like utility based on [Lucene Monitor](https://lucene.apache.org/core/8_7_0
 - Scoring mode (disables highlighting for now)
 - Supports [STDIN](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)) as text input
 - Supports [GLOB](https://en.wikipedia.org/wiki/Glob_(programming)) [file pattern](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
+- Support excluding files from processing with GLOB
 - Compiled with [GraalVM native-image](https://www.graalvm.org/reference-manual/native-image/) tool
 - Supports Linux, MacOS, and Windows
 - Fast startup which makes it usable as CLI utility
@@ -71,6 +72,12 @@ Various options with GLOB file pattern example:
 ./lmgrep --case-sensitive\?=false --ascii-fold\?=true --stem\?=true --tokenizer=whitespace "lucene" "**/*.md"
 ```
 TIP: write GLOB file patterns within double quotes.
+
+We can exclude files also with a GLOB pattern.
+```shell
+./lmgrep "lucene" "**/*.md" --excludes="README.md"
+```
+TIP: a GLOB pattern is treated as recursive if it contains "**", otherwise GLOB matches only on file name.
 
 ## Deviations from Lucene query syntax
 
@@ -238,7 +245,6 @@ Each individual score is BM25 which is default in Lucene.
 ## Future work
 
 - [ ] Optimize matching by [processing lines in batches](https://github.com/dainiusjocas/lucene-grep/issues/3)
-- [ ] Exclude files with [GLOB](https://github.com/dainiusjocas/lucene-grep/issues/5)
 - [ ] Automate builds for [multiple platforms](https://github.com/dainiusjocas/lucene-grep/issues/9)
 
 ## License

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -59,6 +59,7 @@
    [nil "--template TEMPLATE" "The template for the output string, e.g.: file={{file}} line-number={{line-number}} line={{line}}"]
    [nil "--pre-tags PRE_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --post-tags"]
    [nil "--post-tags POST_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --pre-tags"]
+   [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)
    ; :default 0]
@@ -74,4 +75,5 @@
   (lmgrep.cli/handle-args ["--tokenizer=standard" "--stem?=false" "--stemmer=english" "--case-sensitive?=true"])
   (lmgrep.cli/handle-args ["test"])
   (lmgrep.cli/handle-args ["--format=edn"])
+  (lmgrep.cli/handle-args ["--excludes=**.edn"])
   (lmgrep.cli/handle-args ["--with-score"]))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -93,7 +93,7 @@
                            options)]
         highlighter-fn (lucene/highlighter dictionary)]
     (if files-pattern
-      (doseq [path (fs/get-files files-pattern)]
+      (doseq [path (fs/get-files files-pattern options)]
         (with-open [rdr (io/reader path)]
           (match-lines highlighter-fn path (line-seq rdr) options)))
       (when (.ready ^Reader *in*)


### PR DESCRIPTION
Helps to limit the scope of the search.

closes #5