### PR TITLE
Option to skip binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Compile Linux executable with `--static` flag
 - Dockerfile to build static Linux executables
 
+### Unreleased
+
+### New
+
+- Option to skip binary files on Linux and MacOS
+
 ### v2021.01.13
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 - Compile Linux executable with `--static` flag
 - Dockerfile to build static Linux executables
-
-### Unreleased
-
-### New
-
 - Option to skip binary files on Linux and MacOS
+- Updated the native-image docker to 21.0.0
 
 ### v2021.01.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Option to skip binary files on Linux and MacOS
 - Updated the native-image docker to 21.0.0
 
-### v2021.01.13
+### v2021.01.15
 
 ### New
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oracle/graalvm-ce:21.0.0-java11 as BUILDER
+FROM ghcr.io/graalvm/graalvm-ce:java11-21.0.0 as BUILDER
 
 ENV GRAALVM_HOME=$JAVA_HOME
 
@@ -8,7 +8,7 @@ RUN gu install native-image \
     && ./linux-install-1.10.1.727.sh \
     && rm linux-install-1.10.1.727.sh
 
-RUN yum install -y git maven
+RUN microdnf install -y git maven
 
 RUN git clone https://github.com/gunnarmorling/search.morling.dev.git
 RUN (cd search.morling.dev && sh mvnw install || true)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Supported options:
       --pre-tags PRE_TAGS                      A string that the highlighted text is wrapped in, use in conjunction with --post-tags
       --post-tags POST_TAGS                    A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                      A GLOB that filters out files that were matched with a GLOB
+      --skip-binary                            If a file that is detected to be binary should be skipped. Available for Linux only.
   -h, --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Supported options:
       --pre-tags PRE_TAGS                      A string that the highlighted text is wrapped in, use in conjunction with --post-tags
       --post-tags POST_TAGS                    A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                      A GLOB that filters out files that were matched with a GLOB
-      --skip-binary                            If a file that is detected to be binary should be skipped. Available for Linux only.
+      --skip-binary                            If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
   -h, --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Supported options:
       --pre-tags PRE_TAGS                      A string that the highlighted text is wrapped in, use in conjunction with --post-tags
       --post-tags POST_TAGS                    A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                      A GLOB that filters out files that were matched with a GLOB
-      --skip-binary                            If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
+      --skip-binary-files                      If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
   -h, --help
 ```
 

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -60,6 +60,8 @@
    [nil "--pre-tags PRE_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --post-tags"]
    [nil "--post-tags POST_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --pre-tags"]
    [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
+   [nil "--skip-binary" "If a file that is detected to be binary should be skipped. Available for Linux only."
+    :default false]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)
    ; :default 0]

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -60,7 +60,7 @@
    [nil "--pre-tags PRE_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --post-tags"]
    [nil "--post-tags POST_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --pre-tags"]
    [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
-   [nil "--skip-binary" "If a file that is detected to be binary should be skipped. Available for Linux and MacOS only."
+   [nil "--skip-binary-files" "If a file that is detected to be binary should be skipped. Available for Linux and MacOS only."
     :default false]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -60,7 +60,7 @@
    [nil "--pre-tags PRE_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --post-tags"]
    [nil "--post-tags POST_TAGS" "A string that the highlighted text is wrapped in, use in conjunction with --pre-tags"]
    [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
-   [nil "--skip-binary" "If a file that is detected to be binary should be skipped. Available for Linux only."
+   [nil "--skip-binary" "If a file that is detected to be binary should be skipped. Available for Linux and MacOS only."
     :default false]
    ;[nil "--slop SLOP" "How far can be words from each other"
    ; :parse-fn #(Integer/parseInt %)

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -15,7 +15,7 @@
              "charset=binary"))
 
 (defn remove-binary-files [file-paths options]
-  (if (and (:skip-binary options) file-options)
+  (if (and (:skip-binary-files options) file-options)
     (remove binary-file? file-paths)
     file-paths))
 
@@ -64,5 +64,5 @@
   (lmgrep.fs/get-files "**.clj" {})
   (lmgrep.fs/get-files "**.clj" {:excludes "**test*"})
   (lmgrep.fs/get-files "**/*.clj" {})
-  (time (count (lmgrep.fs/get-files "**.*" {:skip-binary true})))
+  (time (count (lmgrep.fs/get-files "**.*" {:skip-binary-files true})))
   (lmgrep.fs/get-files "/var/log/**.log" {}))

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -64,5 +64,5 @@
   (lmgrep.fs/get-files "**.clj" {})
   (lmgrep.fs/get-files "**.clj" {:excludes "**test*"})
   (lmgrep.fs/get-files "**/*.clj" {})
-  (lmgrep.fs/get-files "classes/**.class" {})
+  (time (count (lmgrep.fs/get-files "**.*" {:skip-binary true})))
   (lmgrep.fs/get-files "/var/log/**.log" {}))

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -7,6 +7,7 @@
 
 (def file-options (case (System/getProperty "os.name")
                     "Linux" "-ib"
+                    "Mac OS X" "-I"
                     nil))
 
 (defn binary-file? [^String file-path]

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -100,4 +100,7 @@
         (match-lines highlighter-fn nil (line-seq (BufferedReader. *in*)) options)))))
 
 (comment
-  (lmgrep.grep/grep "opt" "**.md" {:format :edn}))
+  (lmgrep.grep/grep "opt" "**.md" {:format :edn})
+
+  (time (lmgrep.grep/grep "opt" "**.class" {:format      :edn
+                                            :skip-binary false})))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -102,5 +102,5 @@
 (comment
   (lmgrep.grep/grep "opt" "**.md" {:format :edn})
 
-  (time (lmgrep.grep/grep "opt" "**.class" {:format      :edn
-                                            :skip-binary false})))
+  (time (lmgrep.grep/grep "opt" "**.class" {:format            :edn
+                                            :skip-binary-files true})))


### PR DESCRIPTION
For small files, the overhead is not worth it. But when bigger files are being skipped then speedup is huge.

closes #28