### PR TITLE
Support multiple files as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+### Changed
+
+- Accepts multiple files (#30)
+
 ## v2021.02.02
 
 ### Changed

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -11,7 +11,7 @@
 
 (defn -main [& args]
   (let [{:keys [options arguments errors summary]
-         [lucene-query file-pattern] :arguments} (cli/handle-args args)]
+         [lucene-query file-pattern & files] :arguments} (cli/handle-args args)]
     (when (seq errors)
       (println "Errors:" errors)
       (print-summary-msg summary)
@@ -19,5 +19,5 @@
     (when (or (:help options) (zero? (count arguments)))
       (print-summary-msg summary)
       (System/exit 1))
-    (grep/grep lucene-query file-pattern options))
+    (grep/grep lucene-query file-pattern files options))
   (System/exit 0))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -83,7 +83,7 @@
                    :string (string-output highlights details options)
                    (string-output highlights details options)))))))
 
-(defn grep [query-string files-pattern options]
+(defn grep [query-string files-pattern files options]
   (let [dictionary [(merge {:text            query-string
                             :case-sensitive? false
                             :ascii-fold?     true
@@ -93,7 +93,7 @@
                            options)]
         highlighter-fn (lucene/highlighter dictionary)]
     (if files-pattern
-      (doseq [path (fs/get-files files-pattern options)]
+      (doseq [path (concat (fs/get-files files-pattern options) files)]
         (if (:split options)
           (with-open [rdr (io/reader path)]
             (match-lines highlighter-fn path (line-seq rdr) options))


### PR DESCRIPTION
Supports nasty tricks like 

```
fd laser | xargs lmgrep 'laser'
```

closes #30 