### PR TITLE
Native image building main-opts split string

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,7 @@
    :exec-fn      hf.depstar/uberjar
    :exec-args    {:aot true}}
   :native
-  {:main-opts  ["-m clj.native-image lmgrep.core"
+  {:main-opts  ["-m" "clj.native-image" "lmgrep.core"
                 "--no-fallback"
                 "--initialize-at-build-time"
                 "-H:+ReportExceptionStackTraces"
@@ -42,7 +42,7 @@
                               org.slf4j/slf4j-nop]
                  :sha        "f3e40672d5c543b80a2019c1f07b2d3fe785962c"}}}
   :native-linux-static
-  {:main-opts  ["-m clj.native-image lmgrep.core"
+  {:main-opts  ["-m" "clj.native-image" "lmgrep.core"
                 "--no-fallback"
                 "--static"
                 "--initialize-at-build-time"


### PR DESCRIPTION
New version of clojure tools refuses to interpret "-m core" as two different strings.
