### PR TITLE
Support multiple Lucene query strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install clojure tools-deps
         uses: DeLaGuardo/setup-clojure@master
         with:
-          tools-deps: 1.10.2.796
+          tools-deps: 1.10.3.814
 
       - name: Unit Tests
         run: clojure -A:dev:test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+### New
+
+- Allows specifying multiple queries with the `--query` flags.
+
 ## Fixed/enhanced
 
 - Use the `io.quarkiverse.lucene/quarkus-lucene` extension instead of building from source

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Startup and memory as measured with `time` utility on my Linux laptop:
 <img src="docs/time-memory-usage.png"
 alt="Startup time and memory usage" title="Startup time and memory usage" />
 
-The output has a format: `[FILE_PATH]:[LINE_NUMBER]:[LINE_WITH_A_COLORED_HIGHLIGHT]`
+The default output has a format: `[FILE_PATH]:[LINE_NUMBER]:[LINE_WITH_A_COLORED_HIGHLIGHT]`
 
 NOTE: Not compatible with `grep`. When compared with `grep` the functionality is limited in most aspects.
 
@@ -78,7 +78,15 @@ We can exclude files also with a GLOB pattern.
 ```shell
 ./lmgrep "lucene" "**/*.md" --excludes="README.md"
 ```
-TIP: a GLOB pattern is treated as recursive if it contains "**", otherwise GLOB matches only on file name.
+TIP: a GLOB pattern is treated as recursive if it contains "**", otherwise the GLOB is matched only against the file name.
+
+Provide multiple queries:
+```shell
+echo "Lucene is\n awesome" |  lmgrep --query=lucene --query=awesome
+=>
+*STDIN*:1:Lucene is
+*STDIN*:2: awesome
+```
 
 ## Deviations from Lucene query syntax
 
@@ -89,6 +97,7 @@ TIP: a GLOB pattern is treated as recursive if it contains "**", otherwise GLOB 
 Lucene Monitor based grep-like utility.
 Usage: lmgrep [OPTIONS] LUCENE_QUERY [FILES]
 Supported options:
+  -q, --query QUERY                              Lucene query string(s). If specified then all the positional arguments are interpreted as files.
       --tokenizer TOKENIZER                      Tokenizer to use, one of: [keyword letter standard unicode-whitespace whitespace]
       --case-sensitive? CASE_SENSITIVE    false  If text should be case sensitive
       --ascii-fold? ASCII_FOLDED          true   If text should be ascii folded
@@ -232,7 +241,7 @@ make lint
 
 When `{{highlighted-line}}` is used then `--pre-tags` and `--post-tags` options are available, e.g.:
 ```shell
-echo "some text to to match" | clojure -M -m lmgrep.core "text" --pre-tags="<em>" --post-tags="</em>" --template="{{highlighted-line}}"
+echo "some text to to match" | lmgrep "text" --pre-tags="<em>" --post-tags="</em>" --template="{{highlighted-line}}"
 =>
 some <em>text</em> to to match
 ```

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
  :aliases
  {:dev
   {:extra-paths ["dev" "classes" "test" "test/resources"]
-   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.901"
+   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.905"
                                                :exclusions  [org.slf4j/slf4j-log4j12
                                                              org.slf4j/slf4j-api
                                                              org.slf4j/slf4j-nop]}

--- a/src/lmgrep/ansi_escapes.clj
+++ b/src/lmgrep/ansi_escapes.clj
@@ -1,0 +1,17 @@
+(ns lmgrep.ansi-escapes)
+
+(defn red-text [text]
+  (str \ "[1;31m" text \ "[0m"))
+
+(defn purple-text [text]
+  (str \ "[0;35m" text \ "[0m"))
+
+(def SEP ";")
+(def BEL "\u0007")
+(def OSC "\u001B]")
+
+(defn link [text url]
+  (str OSC "8" SEP SEP url BEL text OSC "8" SEP SEP BEL))
+
+(defn green-text [text]
+  (str \ "[0;32m" text \ "[0m"))

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -37,7 +37,11 @@
   (print-str (mapv name (sort options))))
 
 (def cli-options
-  [[nil "--tokenizer TOKENIZER" (str "Tokenizer to use, one of: " (options-to-str tokenizers))
+  [["-q" "--query QUERY"
+    "Lucene query string(s). If specified then all the positional arguments are interpreted as files."
+    :multi true
+    :update-fn conj]
+   [nil "--tokenizer TOKENIZER" (str "Tokenizer to use, one of: " (options-to-str tokenizers))
     :parse-fn #(keyword (str/lower-case %))
     :validate [#(contains? tokenizers %) (str "Tokenizer must be one of: " (options-to-str tokenizers))]]
    [nil "--case-sensitive? CASE_SENSITIVE" "If text should be case sensitive"
@@ -77,6 +81,7 @@
 (comment
   (lmgrep.cli/handle-args ["--tokenizer=standard" "--stem?=false" "--stemmer=english" "--case-sensitive?=true"])
   (lmgrep.cli/handle-args ["test"])
+  (lmgrep.cli/handle-args ["test" "-q" "foo" "--query=bar"])
   (lmgrep.cli/handle-args ["--format=edn"])
   (lmgrep.cli/handle-args ["--excludes=**.edn"])
   (lmgrep.cli/handle-args ["--with-score"]))

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -11,7 +11,7 @@
 
 (defn -main [& args]
   (let [{:keys [options arguments errors summary]
-         [lucene-query file-pattern & files] :arguments} (cli/handle-args args)]
+         [lucene-query file-pattern & files :as positional-arguments] :arguments} (cli/handle-args args)]
     (when (seq errors)
       (println "Errors:" errors)
       (print-summary-msg summary)
@@ -20,5 +20,7 @@
       (print-summary-msg summary)
       (when-not (:help options)
         (System/exit 1)))
-    (grep/grep lucene-query file-pattern files options))
+    (if-let [lucene-queries (seq (:query options))]
+      (grep/grep lucene-queries (first positional-arguments) (rest positional-arguments) options)
+      (grep/grep [lucene-query] file-pattern files options)))
   (System/exit 0))

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -16,7 +16,7 @@
       (println "Errors:" errors)
       (print-summary-msg summary)
       (System/exit 1))
-    (when (or (:help options) (zero? (count arguments)))
+    (when (or (:help options) (and (zero? (count arguments)) (empty? (:query options))))
       (print-summary-msg summary)
       (when-not (:help options)
         (System/exit 1)))

--- a/src/lmgrep/formatter.clj
+++ b/src/lmgrep/formatter.clj
@@ -1,0 +1,58 @@
+(ns lmgrep.formatter
+  (:require [lmgrep.ansi-escapes :as ansi]
+            [clojure.string :as str]
+            [clojure.java.io :as io]))
+
+(defn highlight-line
+  "TODO: overlapping phrase highlights are combined under one color, maybe solve it?"
+  [line-str highlights options]
+  (if (:with-score options)
+    line-str
+    (let [highlights (sort-by :begin-offset highlights)]
+      (when (seq highlights)
+        (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                             #(str (:pre-tags options) % (:post-tags options))
+                             ansi/red-text)]
+          (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
+                 acc ""
+                 last-position 0]
+            (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
+                  highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
+                              (if (< (:begin-offset ann) last-position)
+                                ; adjusting highlight text for overlap
+                                (highlight-fn (subs text-to-highlight (- last-position (:begin-offset ann))))
+                                (highlight-fn text-to-highlight)))
+                  suffix (if (nil? next-ann)
+                           (subs line-str (:end-offset ann))
+                           (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
+                                                                 (:end-offset ann))))]
+              (if (nil? next-ann)
+                (str acc prefix highlight suffix)
+                (recur ann-pairs
+                       (str acc prefix highlight suffix)
+                       (long (max (:begin-offset next-ann)
+                                  (:end-offset ann))))))))))))
+
+(defn file-string [file options]
+  (if (:hyperlink options)
+    (ansi/link file (str (.toURI (io/file file))))
+    file))
+
+(defn string-output [highlights {:keys [file line-number line score]} options]
+  (if-let [template (:template options)]
+    (-> template
+        (str/replace "{{file}}" (or (file-string file options) ""))
+        (str/replace "{{line-number}}" (str line-number))
+        (str/replace "{{highlighted-line}}" (highlight-line line highlights options))
+        (str/replace "{{line}}" line)
+        (str/replace "{{score}}" (str score)))
+    (if score
+      (format "%s:%s:%s:%s"
+              (ansi/purple-text (or (file-string file options) "*STDIN*"))
+              (ansi/green-text line-number)
+              (ansi/purple-text score)
+              (highlight-line line highlights options))
+      (format "%s:%s:%s"
+              (ansi/purple-text (or (file-string file options) "*STDIN*"))
+              (ansi/green-text line-number)
+              (highlight-line line highlights options)))))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -3,78 +3,9 @@
             [clojure.string :as str]
             [jsonista.core :as json]
             [lmgrep.fs :as fs]
+            [lmgrep.formatter :as formatter]
             [lmgrep.lucene :as lucene])
   (:import (java.io BufferedReader Reader)))
-
-(defn red-text [text]
-  (str \ "[1;31m" text \ "[0m"))
-
-(defn purple-text [text]
-  (str \ "[0;35m" text \ "[0m"))
-
-(def SEP ";")
-(def BEL "\u0007")
-(def OSC "\u001B]")
-
-(defn link [text url]
-  (str OSC "8" SEP SEP url BEL text OSC "8" SEP SEP BEL))
-
-(defn green-text [text]
-  (str \ "[0;32m" text \ "[0m"))
-
-(defn highlight-line
-  "TODO: overlapping phrase highlights are combined under one color, maybe solve it?"
-  [line-str highlights options]
-  (if (:with-score options)
-    line-str
-    (let [highlights (sort-by :begin-offset highlights)]
-      (when (seq highlights)
-        (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
-                             #(str (:pre-tags options) % (:post-tags options))
-                             red-text)]
-          (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
-                 acc ""
-                 last-position 0]
-            (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
-                  highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
-                              (if (< (:begin-offset ann) last-position)
-                                ; adjusting highlight text for overlap
-                                (highlight-fn (subs text-to-highlight (- last-position (:begin-offset ann))))
-                                (highlight-fn text-to-highlight)))
-                  suffix (if (nil? next-ann)
-                           (subs line-str (:end-offset ann))
-                           (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
-                                                                 (:end-offset ann))))]
-              (if (nil? next-ann)
-                (str acc prefix highlight suffix)
-                (recur ann-pairs
-                       (str acc prefix highlight suffix)
-                       (long (max (:begin-offset next-ann)
-                                  (:end-offset ann))))))))))))
-
-(defn file-string [file options]
-  (if (:hyperlink options)
-    (link file (str (.toURI (io/file file))))
-    file))
-
-(defn string-output [highlights {:keys [file line-number line score]} options]
-  (if-let [template (:template options)]
-    (-> template
-        (str/replace "{{file}}" (or (file-string file options) ""))
-        (str/replace "{{line-number}}" (str line-number))
-        (str/replace "{{highlighted-line}}" (highlight-line line highlights options))
-        (str/replace "{{line}}" line)
-        (str/replace "{{score}}" (str score)))
-    (if score
-      (format "%s:%s:%s:%s"
-              (purple-text (or (file-string file options) "*STDIN*"))
-              (green-text line-number)
-              (purple-text score)
-              (highlight-line line highlights options))
-      (format "%s:%s:%s"
-              (purple-text (or (file-string file options) "*STDIN*"))
-              (green-text line-number)
-              (highlight-line line highlights options)))))
 
 (defn compact [m] (into {} (remove (comp nil? second) m)))
 
@@ -93,8 +24,8 @@
         (println (case (:format options)
                    :edn (pr-str details)
                    :json (json/write-value-as-string details)
-                   :string (string-output highlights details options)
-                   (string-output highlights details options)))))))
+                   :string (formatter/string-output highlights details options)
+                   (formatter/string-output highlights details options)))))))
 
 (def default-text-analysis
   {:case-sensitive?             false

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -1,5 +1,7 @@
 (ns lmgrep.grep-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [lmgrep.formatter :as formatter]
             [lmgrep.grep :as grep]
             [lmgrep.lucene :as lucene]))
 
@@ -9,4 +11,33 @@
           highlighter-fn (lucene/highlighter [{:text query-string}])
           text "prefix text suffix"]
       (is (= (str "prefix " \ "[1;31mtext" \ "[0m suffix")
-             (grep/highlight-line text (highlighter-fn text) {}))))))
+             (formatter/highlight-line text (highlighter-fn text) {}))))))
+
+(deftest grepping-file
+  (let [file "test/resources/test.txt"
+        query "fox"
+        options {:split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+    (is (= "The quick brown >fox< jumps over the lazy dog"
+           (str/trim
+             (with-out-str
+               (grep/grep [query] file nil options)))))))
+
+(deftest grepping-stdin
+  (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
+        query "fox"
+        options {:split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+    (is (= "The quick brown >fox< jumps over the lazy dog"
+           (with-in-str text-from-stdin
+                        (str/trim
+                          (with-out-str
+                            (grep/grep [query] nil nil options))))))))
+
+(deftest grepping-multiple-queries
+  (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
+        queries ["fox" "dog"]
+        options {:split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+    (is (= "The quick brown >fox< jumps over the lazy >dog<"
+           (with-in-str text-from-stdin
+                        (str/trim
+                          (with-out-str
+                            (grep/grep queries nil nil options))))))))

--- a/test/resources/test.txt
+++ b/test/resources/test.txt
@@ -1,0 +1,2 @@
+The quick brown fox jumps over the lazy dog
+Apache Lucene™ is a high-performance, full-featured text search engine library written entirely in Java. It is a technology suitable for nearly any application that requires full-text search, especially cross-platform.


### PR DESCRIPTION
Allows specifying multiple queries separately:

```
lmgrep --query=test --query=opt README.md
```

closes #58 