### PR TITLE
Do no check if *in* is ready

### DIFF
--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -46,10 +46,9 @@
           (with-open [rdr (io/reader path)]
             (match-lines highlighter-fn path (line-seq rdr) options))
           (match-lines highlighter-fn path [(slurp path)] options)))
-      (when (.ready ^Reader *in*)
-        (if (:split options)
-          (match-lines highlighter-fn nil (line-seq (BufferedReader. *in*)) options)
-          (match-lines highlighter-fn nil [(str/trim (slurp *in*))] options))))))
+      (if (:split options)
+        (match-lines highlighter-fn nil (line-seq (BufferedReader. *in*)) options)
+        (match-lines highlighter-fn nil [(str/trim (slurp *in*))] options)))))
 
 (comment
   (lmgrep.grep/grep ["opt"] "**.md" nil {:format :edn})


### PR DESCRIPTION
Having the `ready` check prevents opening a pipe into the process and holding on to it.

This means that command like this `$ lmgrep 'test'` will hang waiting for the input. Other than that, the behaviours is not changed.
