### PR TITLE
Write empty line on no match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+## Fixed/enhanced
+
+- Handle the zero queries input
+
 ## v2021.03.17
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+## New
+
+- Flag to force printing an empty line on no match 
+
 ## v2021.03.18
 
 ## Fixed/enhanced

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Supported options:
       --post-tags POST_TAGS                      A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                        A GLOB that filters out files that were matched with a GLOB
       --skip-binary-files                        If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
+      --with-empty-lines                         When provided on the input that does not match write an empty line to STDOUT.
       --[no-]split                               If a file (or STDIN) should be split by newline.
       --hyperlink                                If a file should be printed as hyperlinks.
       --word-delimiter-graph-filter WDGF  0      WordDelimiterGraphFilter configurationFlags as per https://lucene.apache.org/core/7_4_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.html

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -68,6 +68,8 @@
    [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
    [nil "--skip-binary-files" "If a file that is detected to be binary should be skipped. Available for Linux and MacOS only."
     :default false]
+   [nil "--with-empty-lines" "When provided on the input that doesn't match write an empty line to STDOUT."
+    :default false]
    [nil "--[no-]split" "If a file (or STDIN) should be split by newline."
     :default true]
    [nil "--hyperlink" "If a file should be printed as hyperlinks."

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -17,7 +17,7 @@
 (defn match-lines [highlighter-fn file-path lines options]
   (doseq [[line-str line-number] (map (fn [line-str line-number] [line-str line-number])
                                       lines (range))]
-    (when-let [highlights (seq (highlighter-fn line-str (select-keys options [:with-score])))]
+    (if-let [highlights (seq (highlighter-fn line-str (select-keys options [:with-score])))]
       (let [details (compact {:file        file-path
                               :line-number (inc line-number)
                               :line        line-str
@@ -26,7 +26,9 @@
                    :edn (pr-str details)
                    :json (json/write-value-as-string details)
                    :string (formatter/string-output highlights details options)
-                   (formatter/string-output highlights details options)))))))
+                   (formatter/string-output highlights details options))))
+      (when (:with-empty-lines options)
+        (println)))))
 
 (def default-text-analysis
   {:case-sensitive?             false

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -55,3 +55,15 @@
                         (str/trim
                           (with-out-str
                             (grep/grep queries nil nil options))))))))
+
+(deftest grepping-when-no-match-with-flag-to-println-empty-line
+  (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
+        query "foo"
+        options {:split true
+                 :pre-tags ">"
+                 :post-tags "<"
+                 :with-empty-lines true
+                 :template "{{highlighted-line}}"}]
+    (is (= "\n" (with-in-str text-from-stdin
+                             (with-out-str
+                               (grep/grep [query] nil nil options)))))))


### PR DESCRIPTION
flag `--with-empty-lines`

Example:
```
 echo "one\ntwo\nthree" | ./lmgrep "one OR Three" --with-empty-lines
=>
*STDIN*:1:one

*STDIN*:3:three
```

![image](https://user-images.githubusercontent.com/230044/111625395-78e5de80-87f5-11eb-90fa-9be44d851d77.png)
