### PR TITLE
Printout the details of the matching when output format is JSON or EDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## New
 
-- Flag to force printing an empty line on no match 
+- Flag to force printing an empty line on no match `--with-empty-lines`
+- Flag to output matching details, `--with-details`
 
 ## v2021.03.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+## Fixed/enhanced
+
+- Handle the zero queries input
+
 ## v2021.03.17
 
 ### New

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ Supported options:
       --post-tags POST_TAGS                      A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                        A GLOB that filters out files that were matched with a GLOB
       --skip-binary-files                        If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
-      --with-empty-lines                         When provided on the input that does not match write an empty line to STDOUT.
+      --with-empty-lines                         When provided on the input that doesn't match write an empty line to STDOUT.
       --[no-]split                               If a file (or STDIN) should be split by newline.
       --hyperlink                                If a file should be printed as hyperlinks.
+      --with-details                             For JSON and EDN output adds raw highlights list.
       --word-delimiter-graph-filter WDGF  0      WordDelimiterGraphFilter configurationFlags as per https://lucene.apache.org/core/7_4_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.html
   -h, --help
 ```

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -74,6 +74,8 @@
     :default true]
    [nil "--hyperlink" "If a file should be printed as hyperlinks."
     :default false]
+   [nil "--with-details" "For JSON and EDN output adds raw highlights list."
+    :default false]
    [nil "--word-delimiter-graph-filter WDGF" "WordDelimiterGraphFilter configurationFlags as per https://lucene.apache.org/core/7_4_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.html"
     :parse-fn #(Integer/parseInt %)
     :default 0]

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -14,6 +14,11 @@
   (when-let [scores (seq (remove nil? (map :score highlights)))]
     (reduce + scores)))
 
+(defn printable-highlights [highlights]
+  (map (fn [h] (-> h
+                   (assoc :query (:text h))
+                   (dissoc :text))) highlights))
+
 (defn match-lines [highlighter-fn file-path lines options]
   (doseq [[line-str line-number] (map (fn [line-str line-number] [line-str line-number])
                                       lines (range))]
@@ -21,7 +26,10 @@
       (let [details (compact {:file        file-path
                               :line-number (inc line-number)
                               :line        line-str
-                              :score       (sum-score highlights)})]
+                              :score       (sum-score highlights)
+                              :highlights  (if (:with-details options)
+                                             (printable-highlights highlights)
+                                             nil)})]
         (println (case (:format options)
                    :edn (pr-str details)
                    :json (json/write-value-as-string details)

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -1,6 +1,7 @@
 (ns lmgrep.grep-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
+            [jsonista.core :as json]
             [lmgrep.formatter :as formatter]
             [lmgrep.grep :as grep]
             [lmgrep.lucene :as lucene]))
@@ -31,6 +32,25 @@
                         (str/trim
                           (with-out-str
                             (grep/grep [query] nil nil options))))))))
+
+(deftest grepping-stdin-with-detailed-json-output
+  (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
+        query "fox"
+        options {:format :json :with-details true}]
+    (is (= {:line-number 1
+            :line        text-from-stdin
+            :highlights  [{:type          "QUERY"
+                           :dict-entry-id "0"
+                           :meta          {}
+                           :begin-offset  16
+                           :end-offset    19
+                           :query         query}]}
+           (json/read-value
+             (with-in-str text-from-stdin
+                         (str/trim
+                           (with-out-str
+                             (grep/grep [query] nil nil options))))
+             json/keyword-keys-object-mapper)))))
 
 (deftest grepping-multiple-queries
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"


### PR DESCRIPTION
Now it will be possible to do such tricks as:
```shell
$ echo "quick brown fox" | clojure -M -m lmgrep.core -q '"quick fox"~1^2' -q fox --format=json --with-details | jq
{
  "line-number": 1,
  "line": "quick brown fox",
  "highlights": [
    {
      "type": "QUERY",
      "dict-entry-id": "0",
      "meta": {},
      "begin-offset": 12,
      "end-offset": 15,
      "query": "fox"
    },
    {
      "type": "QUERY",
      "dict-entry-id": "1",
      "meta": {},
      "begin-offset": 0,
      "end-offset": 15,
      "query": "\"quick fox\"~1^2"
    }
  ]
}

```
