### PR TITLE
Do not print the whole file when no split

### DIFF
--- a/src/lmgrep/formatter.clj
+++ b/src/lmgrep/formatter.clj
@@ -3,36 +3,59 @@
             [clojure.string :as str]
             [clojure.java.io :as io]))
 
+(defn cutout-highlight [input-text highlights options]
+  (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                       #(str (:pre-tags options) % (:post-tags options))
+                       ansi/red-text)]
+    (str "\n" (str/join "\n"
+               (map (fn [highlight]
+                      (let [prefix (subs input-text
+                                         (max 0 (- (:begin-offset highlight) 20))
+                                         (:begin-offset highlight))
+                            suffix (subs input-text
+                                         (:end-offset highlight)
+                                         (min (+ (:end-offset highlight) 20) (.length input-text)))
+                            matched-text (highlight-fn
+                                           (subs input-text
+                                                 (:begin-offset highlight)
+                                                 (:end-offset highlight)))
+                            resp (str/replace (str prefix matched-text suffix) "\n" " ")]
+                        (.println System/err resp)
+                        resp))
+                    highlights)))))
+
 (defn highlight-line
   "TODO: overlapping phrase highlights are combined under one color, maybe solve it?"
   [line-str highlights options]
   (if (:with-score options)
     line-str
     (when (seq highlights)
-      (let [highlights (sort-by :begin-offset highlights)
-            highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
-                           #(str (:pre-tags options) % (:post-tags options))
-                           ansi/red-text)]
-        (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
-               acc ""
-               last-position 0]
-          (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
-                highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
-                            (if (< (:begin-offset ann) last-position)
-                              ; adjusting highlight text for overlap
-                              (highlight-fn (subs text-to-highlight (min (.length text-to-highlight)
-                                                                         (- last-position (:begin-offset ann)))))
-                              (highlight-fn text-to-highlight)))
-                suffix (if (nil? next-ann)
-                         (subs line-str (:end-offset ann))
-                         (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
-                                                               (:end-offset ann))))]
-            (if (nil? next-ann)
-              (str acc prefix highlight suffix)
-              (recur ann-pairs
-                     (str acc prefix highlight suffix)
-                     (long (max (:begin-offset next-ann)
-                                (:end-offset ann)))))))))))
+      (if (get options :split)
+        (let [highlights (sort-by :begin-offset highlights)
+              highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                             #(str (:pre-tags options) % (:post-tags options))
+                             ansi/red-text)]
+          (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
+                 acc ""
+                 last-position 0]
+            (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
+                  highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
+                              (if (< (:begin-offset ann) last-position)
+                                ; adjusting highlight text for overlap
+                                (highlight-fn (subs text-to-highlight (min (.length text-to-highlight)
+                                                                           (- last-position (:begin-offset ann)))))
+                                (highlight-fn text-to-highlight)))
+                  suffix (if (nil? next-ann)
+                           (subs line-str (:end-offset ann))
+                           (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
+                                                                 (:end-offset ann))))]
+              (if (nil? next-ann)
+                (str acc prefix highlight suffix)
+                (recur ann-pairs
+                       (str acc prefix highlight suffix)
+                       (long (max (:begin-offset next-ann)
+                                  (:end-offset ann))))))))
+        (cutout-highlight line-str highlights options)))))
 
 (defn file-string [file line-number options]
   (if (:hyperlink options)

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -13,6 +13,15 @@
              (with-out-str
                (grep/grep [query] file nil options)))))))
 
+(deftest grepping-file-with-no-split
+  (let [file "test/resources/test.txt"
+        query "fox"
+        options {:split false :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+    (is (= "The quick brown >fox< jumps over the lazy dog"
+           (str/trim
+             (with-out-str
+               (grep/grep [query] file nil options)))))))
+
 (deftest grepping-stdin
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "fox"

--- a/test/lmgrep/lucene_test.clj
+++ b/test/lmgrep/lucene_test.clj
@@ -13,7 +13,7 @@
           highlighter-fn (lucene/highlighter [{:query query-string}])
           text "prefix text suffix"]
       (is (= (str "prefix " \ "[1;31mtext" \ "[0m suffix")
-             (formatter/highlight-line text (highlighter-fn text) {}))))))
+             (formatter/highlight-line text (highlighter-fn text) {:split true}))))))
 
 (deftest highlighter-details
   (testing "simple case"


### PR DESCRIPTION
The output should look like:
```
elasticsearch-tools/test/sink/kafka_test.clj
1:(ns sink.kafka-test
2:  (:require [clojure.test :refer [deftest is]]
6:            [test-helpers :as th]))
12:; When working from REPL is source.kafka if modified then the test fails
13:; you need to run tests once again
14:(deftest ^:integration ^:kafka sending-data-to-kafka-with-key-and-headers
15:  (let [test-topic "test-topic"
18:        kafka-opts {:topic test-topic
22:                  :value   {:test "test"}
24:    (th/recreate-topics! [test-topic] {"bootstrap.servers" boostrap-servers})
40:(deftest ^:integration ^:kafka sending-data-to-kafka-without-encoding
41:  (let [test-topic "test-topic-sink-raw"
44:        kafka-opts {:topic test-topic
47:        value {:test "test"}
51:    (th/recreate-topics! [test-topic] {"bootstrap.servers" boostrap-servers})

```