### PR TITLE
feat: --explain to the --only-analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- `--explain` flag for the `--only-analyze` to return details of tokens
+
 ## v2021.04.26
 
 # Fixed/enhanced

--- a/README.md
+++ b/README.md
@@ -138,13 +138,14 @@ Supported options:
       --post-tags POST_TAGS                   A string that the highlighted text is wrapped in, use in conjunction with --pre-tags
       --excludes EXCLUDES                     A GLOB that filters out files that were matched with a GLOB
       --skip-binary-files                     If a file that is detected to be binary should be skipped. Available for Linux and MacOS only.
-      --with-empty-lines                      When provided on the input that doesn't match write an empty line to STDOUT.
+      --with-empty-lines                      When provided on the input that does not match write an empty line to STDOUT.
       --with-scored-highlights                ALPHA: Instructs to highlight with scoring.
       --[no-]split                            If a file (or STDIN) should be split by newline.
       --hyperlink                             If a file should be printed as hyperlinks.
       --with-details                          For JSON and EDN output adds raw highlights list.
       --word-delimiter-graph-filter WDGF      WordDelimiterGraphFilter configurationFlags as per https://lucene.apache.org/core/7_4_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.html
       --only-analyze                          When provided output will be analyzed text.
+      --explain                               Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze APi.
       --analysis ANALYSIS                 {}  The analysis chain configuration
   -h, --help
 ```
@@ -438,6 +439,47 @@ The main thing to understand is that scoring is for every line separately in the
 Another consideration is that scoring is summed up for every line of all the matches. E.g. query "one two" is rewritten by Lucene into two term queries.
 
 Each individual score is BM25 which is default in Lucene.
+
+## `--only-analyze`
+
+Great for debugging.
+
+The output is a list tokens after analyzing the text, e.g.:
+```shell
+echo "Dogs and CAt" | ./lmgrep --only-analyze     
+# => ["dog","and","cat"]
+```
+
+In combination with `--explain` flag outputs the detailed analyzed text similar to Elasticsearch Analyze API, e.g.:
+```shell
+echo "Dogs and CAt" | ./lmgrep --only-analyze --explain | jq
+# => [
+  {
+    "token": "dog",
+    "position": 0,
+    "positionLength": 1,
+    "type": "<ALPHANUM>",
+    "end_offset": 4,
+    "start_offset": 0
+  },
+  {
+    "end_offset": 8,
+    "positionLength": 1,
+    "position": 1,
+    "start_offset": 5,
+    "type": "<ALPHANUM>",
+    "token": "and"
+  },
+  {
+    "position": 2,
+    "token": "cat",
+    "positionLength": 1,
+    "end_offset": 12,
+    "type": "<ALPHANUM>",
+    "start_offset": 9
+  }
+]
+```
 
 ## Future work
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {org.clojure/clojure                        {:mvn/version "1.10.3"}
   org.clojure/tools.cli                      {:mvn/version "1.0.206"}
   org.clojure/tools.logging                  {:mvn/version "1.1.0"}
-  org.clojure/core.async                     {:mvn/version "1.3.610"}
+  org.clojure/core.async                     {:mvn/version "1.3.618"}
   org.apache.lucene/lucene-core              {:mvn/version "8.8.2"}
   org.apache.lucene/lucene-monitor           {:mvn/version "8.8.2"}
   org.apache.lucene/lucene-analyzers-stempel {:mvn/version "8.8.2"}

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -80,8 +80,7 @@
     :parse-fn #(Integer/parseInt %)]
    [nil "--only-analyze" "When provided output will be analyzed text."
     :default false]
-   [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze APi."
-    :default false]
+   [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze APi."]
    [nil "--analysis ANALYSIS" "The analysis chain configuration"
     :parse-fn #(json/read-value % json/keyword-keys-object-mapper)
     :default {}]

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -66,7 +66,7 @@
    [nil "--excludes EXCLUDES" "A GLOB that filters out files that were matched with a GLOB"]
    [nil "--skip-binary-files" "If a file that is detected to be binary should be skipped. Available for Linux and MacOS only."
     :default false]
-   [nil "--with-empty-lines" "When provided on the input that doesn't match write an empty line to STDOUT."
+   [nil "--with-empty-lines" "When provided on the input that does not match write an empty line to STDOUT."
     :default false]
    [nil "--with-scored-highlights" "ALPHA: Instructs to highlight with scoring."
     :default false]

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -80,6 +80,8 @@
     :parse-fn #(Integer/parseInt %)]
    [nil "--only-analyze" "When provided output will be analyzed text."
     :default false]
+   [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze APi."
+    :default false]
    [nil "--analysis ANALYSIS" "The analysis chain configuration"
     :parse-fn #(json/read-value % json/keyword-keys-object-mapper)
     :default {}]

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -110,7 +110,10 @@
   [files-pattern files options]
   (let [analysis-conf (ac/prepare-analysis-configuration ac/default-text-analysis options)
         ^Analyzer analyzer (analyzer/create analysis-conf)
-        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* (* 1024 8192)))]
+        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* (* 1024 8192)))
+        analysis-fn (if (get options :explain)
+                      text-analysis/text->tokens
+                      text-analysis/text->token-strings)]
     (doseq [path (if files-pattern
                    (concat (fs/get-files files-pattern options)
                            (fs/filter-files files))
@@ -123,7 +126,7 @@
                     line-out-chan
                     (map (fn [line]
                            (json/write-value-as-string
-                             (text-analysis/text->token-strings line analyzer))))
+                             (analysis-fn line analyzer))))
                     line-in-chan
                     true
                     (fn [_]

--- a/src/lmgrep/lucene/text_analysis.clj
+++ b/src/lmgrep/lucene/text_analysis.clj
@@ -2,7 +2,7 @@
   (:require [lmgrep.lucene.analyzer :as analyzer]
             [lmgrep.lucene.analysis-conf :as ac])
   (:import (org.apache.lucene.analysis Analyzer TokenStream)
-           (org.apache.lucene.analysis.tokenattributes CharTermAttribute)
+           (org.apache.lucene.analysis.tokenattributes CharTermAttribute FlagsAttribute OffsetAttribute PositionIncrementAttribute TypeAttribute TermFrequencyAttribute PositionLengthAttribute KeywordAttribute)
            (java.io StringReader)))
 
 (defn text->token-strings
@@ -31,3 +31,46 @@
          :stem?                       true
          :stemmer                     :english
          :word-delimiter-graph-filter (+ 1 2 32 64)}))))
+
+(defrecord TokenRecord [token type start_offset end_offset position positionLength])
+
+(defn text->tokens
+  "Given a text and an analyzer returns a list of tokens as strings."
+  [^String text ^Analyzer analyzer]
+  (let [^TokenStream token-stream (.tokenStream analyzer "not-important" (StringReader. text))
+        ^CharTermAttribute termAtt (.addAttribute token-stream CharTermAttribute)
+        ^OffsetAttribute offsetAtt (.addAttribute token-stream OffsetAttribute)
+        ^PositionIncrementAttribute position (.addAttribute token-stream PositionIncrementAttribute)
+        ^TypeAttribute type (.addAttribute token-stream TypeAttribute)
+        ^PositionLengthAttribute pla (.addAttribute token-stream PositionLengthAttribute)]
+    (.reset token-stream)
+    (loop [acc (transient [])
+           pos 0]
+      (if (.incrementToken token-stream)
+        (recur (conj! acc (->TokenRecord (.toString termAtt)
+                                         (.type type)
+                                         (.startOffset offsetAtt)
+                                         (.endOffset offsetAtt)
+                                         pos
+                                         (.getPositionLength pla)))
+               (if (< 1 (.getPositionLength pla))
+                 pos
+                 (+ pos (max (.getPositionIncrement position) 1))))
+        (do
+          (.end token-stream)
+          (.close token-stream)
+          (persistent! acc))))))
+
+(comment
+  (clojure.pprint/print-table
+    (text->tokens
+      "pre BestClass post"
+      (analyzer/create
+        (ac/prepare-analysis-configuration
+          ac/default-text-analysis
+          {:tokenizer                   :whitespace
+           :case-sensitive?             false
+           :ascii-fold?                 false
+           :stem?                       true
+           :stemmer                     :english
+           :word-delimiter-graph-filter (+ 1 2 32 64)})))))

--- a/src/lmgrep/lucene/text_analysis.clj
+++ b/src/lmgrep/lucene/text_analysis.clj
@@ -1,9 +1,10 @@
 (ns lmgrep.lucene.text-analysis
-  (:require [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.analysis-conf :as ac])
-  (:import (org.apache.lucene.analysis Analyzer TokenStream)
-           (org.apache.lucene.analysis.tokenattributes CharTermAttribute FlagsAttribute OffsetAttribute PositionIncrementAttribute TypeAttribute TermFrequencyAttribute PositionLengthAttribute KeywordAttribute)
-           (java.io StringReader)))
+  (:require [lmgrep.lucene.analyzer :as analyzer])
+  (:import (java.io StringReader)
+           (org.apache.lucene.analysis Analyzer TokenStream)
+           (org.apache.lucene.analysis.tokenattributes CharTermAttribute OffsetAttribute
+                                                       PositionIncrementAttribute TypeAttribute
+                                                       PositionLengthAttribute)))
 
 (defn text->token-strings
   "Given a text and an analyzer returns a list of tokens as strings."
@@ -23,14 +24,14 @@
   (text->token-strings
     "foo text bar BestClass fooo name"
     (analyzer/create
-      (ac/prepare-analysis-configuration
-        ac/default-text-analysis
-        {:tokenizer                   :whitespace
-         :case-sensitive?             false
-         :ascii-fold?                 false
-         :stem?                       true
-         :stemmer                     :english
-         :word-delimiter-graph-filter (+ 1 2 32 64)}))))
+      {:tokenizer {:name "whitespace" :args {:rule "java"}},
+       :token-filters [{:name "worddelimitergraph"
+                        :args {"generateWordParts" 1
+                               "generateNumberParts" 1
+                               "preserveOriginal" 1
+                               "splitOnCaseChange" 1}}
+                       {:name "lowercase"}
+                       {:name "englishMinimalStem"}]})))
 
 (defrecord TokenRecord [token type start_offset end_offset position positionLength])
 
@@ -62,15 +63,13 @@
           (persistent! acc))))))
 
 (comment
-  (clojure.pprint/print-table
-    (text->tokens
-      "pre BestClass post"
-      (analyzer/create
-        (ac/prepare-analysis-configuration
-          ac/default-text-analysis
-          {:tokenizer                   :whitespace
-           :case-sensitive?             false
-           :ascii-fold?                 false
-           :stem?                       true
-           :stemmer                     :english
-           :word-delimiter-graph-filter (+ 1 2 32 64)})))))
+  (text->tokens
+    "pre BestClass post"
+    (analyzer/create
+      {:token-filters [{:name "worddelimitergraph"
+                        :args {"generateWordParts"   1
+                               "generateNumberParts" 1
+                               "preserveOriginal"    1
+                               "splitOnCaseChange"   1}}
+                       {:name "lowercase"}
+                       {:name "englishMinimalStem"}]})))

--- a/test/lmgrep/lucene/analysis_test.clj
+++ b/test/lmgrep/lucene/analysis_test.clj
@@ -13,6 +13,23 @@
         analyzer (analysis/create {:analyzer {:name "CollationKeyAnalyzer"}})]
     (is (= ["The brown foxes"] (ta/text->token-strings text analyzer)))))
 
+(deftest detailed-analysis
+  (let [text "The brown foxes"
+        analyzer (analysis/create {:analyzer {:name "EnglishAnalyzer"}})]
+    (is (= [{:end_offset     9
+             :position       0
+             :positionLength 1
+             :start_offset   4
+             :token          "brown"
+             :type           "<ALPHANUM>"}
+            {:end_offset     15
+             :position       2
+             :positionLength 1
+             :start_offset   10
+             :token          "fox"
+             :type           "<ALPHANUM>"}]
+           (map (fn [m] (into {} m)) (ta/text->tokens text analyzer))))))
+
 (deftest analysis-construction-from-components
   (let [text "The quick brown fox"
         analyzer (analysis/create
@@ -159,7 +176,7 @@
                                "hyphenationcompoundword" "length" "type" "synonymgraph" "limittokenoffset"
                                "protectedterm" "limittokenposition" "patternreplace" "ngram" "codepointcount"}
         token-filter-names (remove (fn [tn] (contains? with-required-params tn))
-                                  (keys components))]
+                                   (keys components))]
     (is (seq token-filter-names))
     (doseq [token-filter-name token-filter-names]
       (try


### PR DESCRIPTION
Print tokens with detailed info.
```
echo "Dogs and CAt" | clojure -M -m lmgrep.core --explain \
  --only-analyze \
  --analysis='
    {
      "tokenizer": {"name": "standard"},
      "token-filters": [
        {"name": "lowercase"},
        {"name": "englishminimalstem"
      }
    ]
  }' | jq
# => [
  {
    "token": "dog",
    "position": 0,
    "positionLength": 1,
    "type": "<ALPHANUM>",
    "end_offset": 4,
    "start_offset": 0
  },
  {
    "end_offset": 8,
    "positionLength": 1,
    "position": 1,
    "start_offset": 5,
    "type": "<ALPHANUM>",
    "token": "and"
  },
  {
    "position": 2,
    "token": "cat",
    "positionLength": 1,
    "end_offset": 12,
    "type": "<ALPHANUM>",
    "start_offset": 9
  }
]
```
closes #89 