### PR TITLE
Check if glob is actually a file before globbing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install clojure tools-deps
         uses: DeLaGuardo/setup-clojure@master
         with:
-          tools-deps: 1.10.3.849
+          tools-deps: 1.10.3.875
 
       - name: Unit Tests
         run: clojure -A:dev:test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+## Fixed/enhanced
+
+- Check if the glob is actually a file.
+
 ## v2021.05.23
 
 ## New

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
  :aliases
  {:dev
   {:extra-paths ["dev" "classes" "test" "test/resources"]
-   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.922"
+   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.931"
                                                :exclusions  [org.slf4j/slf4j-log4j12
                                                              org.slf4j/slf4j-api
                                                              org.slf4j/slf4j-nop]}
@@ -22,11 +22,11 @@
   :test
   {:extra-paths ["test" "test/resources"]
    :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                            :sha     "18518c4f8c4142f87efe51ed566a2ae70de01dcb"}}
+                                            :sha     "62ef1de18e076903374306060ac0e8a752e57c86"}}
    :main-opts   ["-m" "cognitect.test-runner"]}
   :clj-kondo
   {:main-opts  ["-m" "clj-kondo.main" "--lint" "src" "test"]
-   :extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.04.23"}}
+   :extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.06.01"}}
    :jvm-opts   ["-Dclojure.main.report=stderr"]}
   :uberjar
   {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -16,7 +16,7 @@
              "charset=binary"))
 
 (defn filter-files [files]
-  (filter (fn [^String file-path] (.isFile ^File (io/file file-path))) files))
+  (r/filter (fn [^String file-path] (.isFile ^File (io/file file-path))) files))
 
 ; TODO: Support regex pattern
 (defn get-files [^String glob options]

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -60,7 +60,6 @@
            (r/foldcat)))))
 
 (comment
-  (time (count (lmgrep.fs/get-files "/home/dj/foo.log" {})))
   (lmgrep.fs/get-files "*.md" {})
 
   (lmgrep.fs/get-files "*.md" {:excludes "README.md"})

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -167,7 +167,7 @@
         (.flush writer)))))
 
 (comment
-  (time (lmgrep.grep/analyze-lines
-     "test/resources/test.txt"
-     nil
-     {})))
+  (lmgrep.grep/analyze-lines
+    "test/resources/test.txt"
+    nil
+    {}))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -3,7 +3,6 @@
             [clojure.string :as str]
             [clojure.core.async :as a]
             [clojure.core.async.impl.protocols :as impl]
-            [clojure.core.reducers :as r]
             [jsonista.core :as json]
             [lmgrep.fs :as fs]
             [lmgrep.formatter :as formatter]

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -96,8 +96,8 @@
   (let [questionnaire (combine-questionnaire lucene-query-strings options)
         highlighter-fn (lucene/highlighter questionnaire options)]
     (if files-pattern
-      (doseq [path (concat (fs/get-files files-pattern options)
-                           (fs/filter-files files))]
+      (doseq [path (into (fs/get-files files-pattern options)
+                         (fs/filter-files files))]
         (if (:split options)
           (with-open [rdr (io/reader path)]
             (match-lines highlighter-fn path (line-seq rdr) options))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -124,11 +124,11 @@
         analysis-fn (if (get options :explain)
                       text-analysis/text->tokens
                       text-analysis/text->token-strings)
-        fta (if files-pattern
-              (into (fs/get-files files-pattern options)
-                    (fs/filter-files files))
-              [nil])]
-    (doseq [path fta]
+        files-to-analyze (if files-pattern
+                           (into (fs/get-files files-pattern options)
+                                 (fs/filter-files files))
+                           [nil])]
+    (doseq [path files-to-analyze]
       (let [line-in-chan (a/chan 1024)
             line-out-chan (a/chan (* 2 1024))]
 

--- a/test/lmgrep/fs_test.clj
+++ b/test/lmgrep/fs_test.clj
@@ -5,3 +5,10 @@
 (deftest filter-for-files
   (let [files ["src" "deps.edn"]]
     (is (= ["deps.edn"] (fs/filter-files files)))))
+
+(deftest binary-file-shipping
+  (when (contains? #{"Linux" "Mac OS X"} (System/getProperty "os.name"))
+    ; NOTE: Windows doesn't support this feature
+    ; All .png files in docs should be binary
+    (is (= [] (fs/get-files "docs/**.png"
+                            {:skip-binary-files true})))))

--- a/test/lmgrep/fs_test.clj
+++ b/test/lmgrep/fs_test.clj
@@ -4,7 +4,7 @@
 
 (deftest filter-for-files
   (let [files ["src" "deps.edn"]]
-    (is (= ["deps.edn"] (fs/filter-files files)))))
+    (is (= ["deps.edn"] (into [] (fs/filter-files files))))))
 
 (deftest binary-file-shipping
   (when (contains? #{"Linux" "Mac OS X"} (System/getProperty "os.name"))


### PR DESCRIPTION
When the directory to which the input file belongs has a lot of files then globbing takes forever. 

The workaround would be to first check if glob is actually a file, and if it is a file then just return this file, and if not a file then glob.

