### PR TITLE
Option for --only-analyze  to maximize throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Add support for the `org.apache.lucene.analysis.miscellaneous.DropIfFlaggedFilterFactory` token filter
 - Add support for the `org.apache.lucene.analysis.pattern.PatternTypingFilter` token filter
 - Flag `--[no-]preserve-order` that attempts to increase throughput while not preserving the order, applicable to `--only-analyze`
+- Flag `--reader-buffer-size` in bytes
+- Flag `--writer-buffer-size` in bytes
 
 ## v2021.05.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - Flag to skip hidden files `--[no-]hidden`
 - Add support for the `org.apache.lucene.analysis.miscellaneous.DropIfFlaggedFilterFactory` token filter
 - Add support for the `org.apache.lucene.analysis.pattern.PatternTypingFilter` token filter
+- Flag `--[no-]preserve-order` that attempts to increase throughput while not preserving the order, applicable to `--only-analyze`
 
 ## v2021.05.23
 

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,7 @@
  :aliases
  {:dev
   {:extra-paths ["dev" "classes" "test" "test/resources"]
-   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.931"
+   :extra-deps  {org.clojure/tools.deps.alpha {:mvn/version "0.11.935"
                                                :exclusions  [org.slf4j/slf4j-log4j12
                                                              org.slf4j/slf4j-api
                                                              org.slf4j/slf4j-nop]}
@@ -23,13 +23,13 @@
   :test
   {:extra-paths ["test" "test/resources"]
    :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                            :sha     "62ef1de18e076903374306060ac0e8a752e57c86"}}
+                                            :sha     "f597341b6ca7bb4cf027e0a34a6710ca9cb969da"}}
    :main-opts   ["-m" "cognitect.test-runner"]}
   :clj-kondo
   {:main-opts  ["-m" "clj-kondo.main" "--lint" "src" "test"]
    :extra-deps {clj-kondo/clj-kondo {:mvn/version "2021.06.18"}}
    :jvm-opts   ["-Dclojure.main.report=stderr"]}
   :uberjar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
+  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.245"}}
    :exec-fn      hf.depstar/uberjar
    :exec-args    {:aot true}}}}

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -98,6 +98,10 @@
    [nil "--concurrency CONCURRENCY" "How many concurrent threads to use for processing."
     :parse-fn #(Integer/parseInt %)
     :default 8]
+   [nil "--reader-buffer-size BUFFER_SIZE" "Buffer size of the BufferedReader in bytes."
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--writer-buffer-size BUFFER_SIZE" "Buffer size of the BufferedWriter in bytes."
+    :parse-fn #(Integer/parseInt %)]
    [nil "--[no-]preserve-order" "If the input order should be preserved."
     :default true]
    ["-h" "--help"]])

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -95,9 +95,11 @@
    [nil "--analysis ANALYSIS" "The analysis chain configuration"
     :parse-fn #(json/read-value % json/keyword-keys-object-mapper)
     :default {}]
-   [nil "--concurrency CONCURRENCY" "How many threads to use to match text while preserving the input order."
+   [nil "--concurrency CONCURRENCY" "How many concurrent threads to use for processing."
     :parse-fn #(Integer/parseInt %)
     :default 8]
+   [nil "--[no-]preserve-order" "If the input order should be preserved."
+    :default true]
    ["-h" "--help"]])
 
 (defn handle-args [args]

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [lmgrep.cli :as cli]
+            [lmgrep.only-analyze :as analyze]
             [lmgrep.grep :as grep])
   (:gen-class))
 
@@ -27,7 +28,7 @@
         (print-summary-msg summary)
         (System/exit 1))
       (if (:only-analyze options)
-        (grep/analyze-lines (first positional-arguments) (rest positional-arguments) options)
+        (analyze/analyze-lines (first positional-arguments) (rest positional-arguments) options)
         (do
           (when (or (:help options) (zero-queries? arguments options))
             (print-summary-msg summary)

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -6,12 +6,8 @@
             [jsonista.core :as json]
             [lmgrep.fs :as fs]
             [lmgrep.formatter :as formatter]
-            [lmgrep.lucene :as lucene]
-            [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.analysis-conf :as ac]
-            [lmgrep.lucene.text-analysis :as text-analysis])
-  (:import (java.io BufferedReader File PrintWriter BufferedWriter)
-           (org.apache.lucene.analysis Analyzer)))
+            [lmgrep.lucene :as lucene])
+  (:import (java.io BufferedReader File PrintWriter BufferedWriter)))
 
 (set! *warn-on-reflection* true)
 
@@ -113,98 +109,3 @@
 
   (time (lmgrep.grep/grep ["opt"] "**.class" nil {:format            :edn
                                                   :skip-binary-files true})))
-
-(defn only-analyze-unordered
-  "Given a line-in-chan that contains strings to analyze, passes every string to the analyze-fn whose
-  output is a JSON-encoded string. The results of the analyze-fn are put on the line-out-chan."
-  [analyze-fn line-in-chan line-out-chan concurrency]
-  (let [not-done (atom concurrency)]
-    (dotimes [_ concurrency]
-      (a/thread
-        (if-let [^String line (a/<!! line-in-chan)]
-          (do
-            (try
-              (a/>!! line-out-chan (analyze-fn line))
-              (catch Throwable t
-                (when (System/getenv "DEBUG_MODE")
-                  (.printStackTrace t))
-                (a/close! line-out-chan)
-                (System/exit 1)))
-            (recur))
-          ; when all threads are done close the output channel, that marks the end of processing
-          (when (zero? (swap! not-done dec))
-            (a/close! line-out-chan)))))))
-
-(defn only-analyze-ordered
-  "Parallel processing pipeline that preserved the input order."
-  [analyze-fn line-in-chan line-out-chan concurrency]
-  (a/pipeline concurrency
-              line-out-chan
-              (map analyze-fn)
-              line-in-chan
-              true
-              (fn [^Throwable t]
-                (when (System/getenv "DEBUG_MODE")
-                  (.printStackTrace t))
-                (a/close! line-out-chan)
-                (System/exit 1))))
-
-(defn read-input-lines-to-channel
-  "Starts a thread that reads strings from an input reader and puts them to a channel."
-  [^BufferedReader input-reader channel]
-  (a/thread
-    (with-open [^BufferedReader rdr input-reader]
-      (loop [^String line (.readLine rdr)]
-        (if (nil? line)
-          (a/close! channel)
-          (do
-            (a/>!! channel line)
-            (recur (.readLine rdr))))))))
-
-(defn write-output-from-channel
-  "Write to data from a channel to PrintWriter on the main thread."
-  [^PrintWriter writer channel]
-  (loop [^String line (a/<!! channel)]
-    (when-not (nil? line)
-      (.println writer line)
-      (recur (a/<!! channel))))
-  (.flush writer))
-
-(defn analyze-lines
-  "Sequence of text into sequence of text token sequences. Output format is JSON.
-  If given file path reads file otherwise stdin."
-  [files-pattern files options]
-  (let [line-in-buffer-size (* 1024 8)
-        line-out-buffer-size (* 1024 8)
-        reader-buffer-size (* 1024 8192)
-        print-writer-buffer-size (* 8192 8192)
-        preserve-order? (get options :preserve-order true)
-        concurrency (get options :concurrency (.availableProcessors (Runtime/getRuntime)))
-        analysis-conf (ac/prepare-analysis-configuration ac/default-text-analysis options)
-        ^Analyzer analyzer (analyzer/create analysis-conf)
-        analysis-fn (if (get options :explain)
-                      text-analysis/text->tokens
-                      text-analysis/text->token-strings)
-        files-to-analyze (if files-pattern
-                           (into (fs/get-files files-pattern options)
-                                 (fs/filter-files files))
-                           [nil])
-        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))]
-    (doseq [path files-to-analyze]
-      (let [line-in-chan (a/chan line-in-buffer-size)
-            line-out-chan (a/chan line-out-buffer-size)
-            analyze-fn (fn [line] (json/write-value-as-string (analysis-fn line analyzer)))]
-        (if preserve-order?
-          (only-analyze-ordered analyze-fn line-in-chan line-out-chan concurrency)
-          (only-analyze-unordered analyze-fn line-in-chan line-out-chan concurrency))
-        (read-input-lines-to-channel (if path
-                                       (io/reader path)
-                                       (BufferedReader. *in* reader-buffer-size))
-                                     line-in-chan)
-        (write-output-from-channel writer line-out-chan)))))
-
-(comment
-  (lmgrep.grep/analyze-lines
-    "test/resources/test.txt"
-    nil
-    {}))

--- a/src/lmgrep/only_analyze.clj
+++ b/src/lmgrep/only_analyze.clj
@@ -1,0 +1,106 @@
+(ns lmgrep.only-analyze
+  (:require [lmgrep.lucene.analyzer :as analyzer]
+            [lmgrep.lucene.analysis-conf :as ac]
+            [clojure.core.async :as a]
+            [lmgrep.lucene.text-analysis :as text-analysis]
+            [lmgrep.fs :as fs]
+            [jsonista.core :as json]
+            [clojure.java.io :as io])
+  (:import (java.io BufferedReader PrintWriter BufferedWriter)
+           (org.apache.lucene.analysis Analyzer)))
+
+
+(defn only-analyze-unordered
+  "Given a line-in-chan that contains strings to analyze, passes every string to the analyze-fn whose
+  output is a JSON-encoded string. The results of the analyze-fn are put on the line-out-chan."
+  [analyze-fn line-in-chan line-out-chan concurrency]
+  (let [not-done (atom concurrency)]
+    (dotimes [_ concurrency]
+      (a/thread
+        (if-let [^String line (a/<!! line-in-chan)]
+          (do
+            (try
+              (a/>!! line-out-chan (analyze-fn line))
+              (catch Throwable t
+                (when (System/getenv "DEBUG_MODE")
+                  (.printStackTrace t))
+                (a/close! line-out-chan)
+                (System/exit 1)))
+            (recur))
+          ; when all threads are done close the output channel, that marks the end of processing
+          (when (zero? (swap! not-done dec))
+            (a/close! line-out-chan)))))))
+
+(defn only-analyze-ordered
+  "Parallel processing pipeline that preserved the input order."
+  [analyze-fn line-in-chan line-out-chan concurrency]
+  (a/pipeline concurrency
+              line-out-chan
+              (map analyze-fn)
+              line-in-chan
+              true
+              (fn [^Throwable t]
+                (when (System/getenv "DEBUG_MODE")
+                  (.printStackTrace t))
+                (a/close! line-out-chan)
+                (System/exit 1))))
+
+(defn read-input-lines-to-channel
+  "Starts a thread that reads strings from an input reader and puts them to a channel."
+  [^BufferedReader input-reader channel]
+  (a/thread
+    (with-open [^BufferedReader rdr input-reader]
+      (loop [^String line (.readLine rdr)]
+        (if (nil? line)
+          (a/close! channel)
+          (do
+            (a/>!! channel line)
+            (recur (.readLine rdr))))))))
+
+(defn write-output-from-channel
+  "Write to data from a channel to PrintWriter on the main thread."
+  [^PrintWriter writer channel]
+  (loop [^String line (a/<!! channel)]
+    (when-not (nil? line)
+      (.println writer line)
+      (recur (a/<!! channel))))
+  (.flush writer))
+
+(defn analyze-lines
+  "Sequence of text into sequence of text token sequences. Output format is JSON.
+  If given file path reads file otherwise stdin."
+  [files-pattern files options]
+  (let [line-in-buffer-size (* 1024 8)
+        line-out-buffer-size (* 1024 8)
+        reader-buffer-size (* 1024 8192)
+        print-writer-buffer-size (* 8192 8192)
+        preserve-order? (get options :preserve-order true)
+        concurrency (get options :concurrency (.availableProcessors (Runtime/getRuntime)))
+        analysis-conf (ac/prepare-analysis-configuration ac/default-text-analysis options)
+        analysis-fn (if (get options :explain)
+                      text-analysis/text->tokens
+                      text-analysis/text->token-strings)
+        files-to-analyze (if files-pattern
+                           (into (fs/get-files files-pattern options)
+                                 (fs/filter-files files))
+                           [nil])
+        ^Analyzer analyzer (analyzer/create analysis-conf)
+        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))]
+    (doseq [path files-to-analyze]
+      (let [line-in-chan (a/chan line-in-buffer-size)
+            line-out-chan (a/chan line-out-buffer-size)
+            analyze-fn (fn [line] (json/write-value-as-string (analysis-fn line analyzer)))]
+        (if preserve-order?
+          (only-analyze-ordered analyze-fn line-in-chan line-out-chan concurrency)
+          (only-analyze-unordered analyze-fn line-in-chan line-out-chan concurrency))
+        (read-input-lines-to-channel (if path
+                                       (io/reader path)
+                                       (BufferedReader. *in* reader-buffer-size))
+                                     line-in-chan)
+        (write-output-from-channel writer line-out-chan)))))
+
+(comment
+  (lmgrep.only-analyze/analyze-lines
+    "test/resources/test.txt"
+    nil
+    {}))

--- a/src/lmgrep/only_analyze.clj
+++ b/src/lmgrep/only_analyze.clj
@@ -1,11 +1,11 @@
 (ns lmgrep.only-analyze
-  (:require [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.analysis-conf :as ac]
-            [clojure.core.async :as a]
-            [lmgrep.lucene.text-analysis :as text-analysis]
-            [lmgrep.fs :as fs]
+  (:require [clojure.core.async :as a]
+            [clojure.java.io :as io]
             [jsonista.core :as json]
-            [clojure.java.io :as io])
+            [lmgrep.lucene.analysis-conf :as ac]
+            [lmgrep.lucene.text-analysis :as text-analysis]
+            [lmgrep.lucene.analyzer :as analyzer]
+            [lmgrep.fs :as fs])
   (:import (java.io BufferedReader PrintWriter BufferedWriter)
            (org.apache.lucene.analysis Analyzer)))
 
@@ -48,17 +48,17 @@
 (defn read-input-lines-to-channel
   "Starts a thread that reads strings from an input reader and puts them to a channel."
   [^BufferedReader input-reader channel]
-  (a/thread
+  (a/go
     (with-open [^BufferedReader rdr input-reader]
       (loop [^String line (.readLine rdr)]
         (if (nil? line)
           (a/close! channel)
           (do
-            (a/>!! channel line)
+            (a/>! channel line)
             (recur (.readLine rdr))))))))
 
 (defn write-output-from-channel
-  "Write to data from a channel to PrintWriter on the main thread."
+  "Write data from a channel to the PrintWriter. Intended to be run on the main thread."
   [^PrintWriter writer channel]
   (loop [^String line (a/<!! channel)]
     (when-not (nil? line)

--- a/src/lmgrep/only_analyze.clj
+++ b/src/lmgrep/only_analyze.clj
@@ -106,10 +106,14 @@
   If given file path reads file otherwise stdin.
 
   Options:
-  - :preserve-order should the output preserve the order of the input."
+  - :concurrency how many threads to use for text analysis.
+  - :explain should the token have the positional and other information.
+  - :preserve-order should the output preserve the order of the input.
+  - :reader-buffer-size in bytes
+  - :writer-buffer-size in bytes"
   [files-pattern files options]
-  (let [reader-buffer-size (* 2 1024 8192)
-        print-writer-buffer-size (* 8192 8192)
+  (let [reader-buffer-size (get options :reader-buffer-size (* 2 1024 8192))
+        print-writer-buffer-size (get options :writer-buffer-size (* 8192 8192))
         preserve-order? (get options :preserve-order true)
         concurrency (get options :concurrency (.availableProcessors (Runtime/getRuntime)))
         analysis-conf (ac/prepare-analysis-configuration ac/default-text-analysis options)

--- a/test/lmgrep/cli_test.clj
+++ b/test/lmgrep/cli_test.clj
@@ -12,7 +12,8 @@
    :with-empty-lines       false
    :with-scored-highlights false
    :concurrency            8
-   :hidden                 true})
+   :hidden                 true
+   :preserve-order         true})
 
 (deftest args-handling
   (testing "positional arguments"

--- a/test/lmgrep/lucene_test.clj
+++ b/test/lmgrep/lucene_test.clj
@@ -1,11 +1,7 @@
 (ns lmgrep.lucene-test
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.string :as str]
             [lmgrep.formatter :as formatter]
-            [lmgrep.grep :as grep]
-            [lmgrep.lucene :as lucene]
-            [jsonista.core :as json]
-            [clojure.string :as s]))
+            [lmgrep.lucene :as lucene]))
 
 (deftest highlighting-test
   (testing "coloring the output"
@@ -48,29 +44,3 @@
                :query         "best class"
                :type          "QUERY"}]
              ((lucene/highlighter dictionary {}) text))))))
-
-(deftest only-analysis
-  (testing "file input ordered"
-    (let [file-path "test/resources/test.txt"
-          options {}]
-      (is (= 2 (count
-                 (str/split-lines
-                   (str/trim
-                     (with-out-str
-                       (grep/analyze-lines file-path nil options)))))))))
-  (testing "multiple lines from stdin ordered"
-    (let [text-from-stdin "foo bar \nbaz quux"
-          analyzer {}]
-      (is (= "[\"foo\",\"bar\"]\n[\"baz\",\"quux\"]\n"
-             (with-in-str text-from-stdin
-                          (with-out-str
-                            (grep/analyze-lines nil nil analyzer)))))))
-
-  (testing "multiple lines from stdin not ordered"
-    (let [text-from-stdin "foo bar \nbaz quux"
-          analyzer {:preserve-order false}]
-      (is (= #{["foo" "bar"] ["baz" "quux"]}
-             (set (map json/read-value (s/split-lines
-                                         (with-in-str text-from-stdin
-                                                      (with-out-str
-                                                        (grep/analyze-lines nil nil analyzer)))))))))))

--- a/test/lmgrep/lucene_test.clj
+++ b/test/lmgrep/lucene_test.clj
@@ -3,7 +3,9 @@
             [clojure.string :as str]
             [lmgrep.formatter :as formatter]
             [lmgrep.grep :as grep]
-            [lmgrep.lucene :as lucene]))
+            [lmgrep.lucene :as lucene]
+            [jsonista.core :as json]
+            [clojure.string :as s]))
 
 (deftest highlighting-test
   (testing "coloring the output"
@@ -48,7 +50,7 @@
              ((lucene/highlighter dictionary {}) text))))))
 
 (deftest only-analysis
-  (testing "file input"
+  (testing "file input ordered"
     (let [file-path "test/resources/test.txt"
           options {}]
       (is (= 2 (count
@@ -56,10 +58,19 @@
                    (str/trim
                      (with-out-str
                        (grep/analyze-lines file-path nil options)))))))))
-  (testing "multiple lines from stdin"
+  (testing "multiple lines from stdin ordered"
     (let [text-from-stdin "foo bar \nbaz quux"
           analyzer {}]
       (is (= "[\"foo\",\"bar\"]\n[\"baz\",\"quux\"]\n"
              (with-in-str text-from-stdin
                           (with-out-str
-                            (grep/analyze-lines nil nil analyzer))))))))
+                            (grep/analyze-lines nil nil analyzer)))))))
+
+  (testing "multiple lines from stdin not ordered"
+    (let [text-from-stdin "foo bar \nbaz quux"
+          analyzer {:preserve-order false}]
+      (is (= #{["foo" "bar"] ["baz" "quux"]}
+             (set (map json/read-value (s/split-lines
+                                         (with-in-str text-from-stdin
+                                                      (with-out-str
+                                                        (grep/analyze-lines nil nil analyzer)))))))))))

--- a/test/lmgrep/only_analyze_test.clj
+++ b/test/lmgrep/only_analyze_test.clj
@@ -1,5 +1,5 @@
 (ns lmgrep.only-analyze-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [jsonista.core :as json]
             [lmgrep.only-analyze :as analyze]))

--- a/test/lmgrep/only_analyze_test.clj
+++ b/test/lmgrep/only_analyze_test.clj
@@ -1,0 +1,31 @@
+(ns lmgrep.only-analyze-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [lmgrep.only-analyze :as analyze]
+            [jsonista.core :as json]))
+
+(deftest only-analysis
+  (testing "file input ordered"
+    (let [file-path "test/resources/test.txt"
+          options {}]
+      (is (= 2 (count
+                 (str/split-lines
+                   (str/trim
+                     (with-out-str
+                       (analyze/analyze-lines file-path nil options)))))))))
+  (testing "multiple lines from stdin ordered"
+    (let [text-from-stdin "foo bar \nbaz quux"
+          analyzer {}]
+      (is (= "[\"foo\",\"bar\"]\n[\"baz\",\"quux\"]\n"
+             (with-in-str text-from-stdin
+                          (with-out-str
+                            (analyze/analyze-lines nil nil analyzer)))))))
+
+  (testing "multiple lines from stdin not ordered"
+    (let [text-from-stdin "foo bar \nbaz quux"
+          analyzer {:preserve-order false}]
+      (is (= #{["foo" "bar"] ["baz" "quux"]}
+             (set (map json/read-value (str/split-lines
+                                         (with-in-str text-from-stdin
+                                                      (with-out-str
+                                                        (analyze/analyze-lines nil nil analyzer)))))))))))


### PR DESCRIPTION
Not preserving the input order and implementing concurrency with Java's ExecutorService.