### PR TITLE
Draw token graph from text

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
   org.apache.lucene/lucene-monitor           {:mvn/version "8.9.0"}
   org.apache.lucene/lucene-analyzers-stempel {:mvn/version "8.9.0"}
   metosin/jsonista                           {:mvn/version "0.3.3"}
-  lt.jocas/lucene-monitor-helpers            {:mvn/version "0.1.4"}
+  lt.jocas/lucene-monitor-helpers            {:mvn/version "0.1.5"}
   babashka/fs                                {:mvn/version "0.0.5"}
   io.quarkiverse.lucene/quarkus-lucene       {:mvn/version "0.2"}}
  :aliases

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -91,7 +91,8 @@
     :parse-fn #(Integer/parseInt %)]
    [nil "--only-analyze" "When provided output will be analyzed text."
     :default false]
-   [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze APi."]
+   [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze API."]
+   [nil "--graph" "Modifies --only-analyze. Output is a string that can be fed to the `dot` program."]
    [nil "--analysis ANALYSIS" "The analysis chain configuration"
     :parse-fn #(json/read-value % json/keyword-keys-object-mapper)
     :default {}]

--- a/src/lmgrep/lucene.clj
+++ b/src/lmgrep/lucene.clj
@@ -1,9 +1,7 @@
 (ns lmgrep.lucene
   (:require [clojure.string :as s]
-            [lmgrep.lucene.analyzer :as analyzer]
             [lmgrep.lucene.matching :as matching]
-            [lmgrep.lucene.monitor :as monitor]
-            [lmgrep.lucene.text-analysis :as text-analysis]))
+            [lmgrep.lucene.monitor :as monitor]))
 
 (defn highlighter
   ([questionnaire] (highlighter questionnaire {}))
@@ -22,21 +20,3 @@
                   :word-delimiter-graph-filter (+ 1 2 32 64)}] {}) "foo text bar BestClass fooo name")
 
   ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true}))
-
-(defn text->tokens [^String text analysis-conf]
-  (text-analysis/text->token-strings text (analyzer/create analysis-conf)))
-
-(comment
-  (text->tokens
-    "foo text bar BestClass name"
-    {:tokenizer {:name "whitespace"
-                 :args {:rule "java"}}
-     :token-filters [{:name "worddelimitergraph"
-                      :args {"generateWordParts" 1
-                             "generateNumberParts" 1
-                             "preserveOriginal" 1
-                             "splitOnCaseChange" 1}}
-                     {:name "lowercase"}
-                     {:name "englishMinimalStem"}]})
-
-  (text->tokens "texting names" {:analyzer {:name "English"}}))

--- a/test/lmgrep/lucene/analysis_test.clj
+++ b/test/lmgrep/lucene/analysis_test.clj
@@ -13,6 +13,11 @@
         analyzer (analysis/create {:analyzer {:name "CollationKeyAnalyzer"}})]
     (is (= ["The brown foxes"] (ta/text->token-strings text analyzer)))))
 
+(deftest graph-from-token-stream
+  (let [text "The brown foxes"
+        analyzer (analysis/create {:analyzer {:name "EnglishAnalyzer"}})]
+    (is (string? (ta/text->graph text analyzer)))))
+
 (deftest detailed-analysis
   (let [text "The brown foxes"
         analyzer (analysis/create {:analyzer {:name "EnglishAnalyzer"}})]


### PR DESCRIPTION
subflag for `--only-analyze` that instructs to spit out dot program to draw token graphs.