### PR TITLE
Flag for --query-update-buffer-size Lucene monitor

### DIFF
--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -109,6 +109,7 @@
     :default true]
    [nil "--config-dir DIR" "A base directory from which to load text analysis resources, e.g. synonym files. Default: current dir."]
    [nil "--analyzers-file FILE" "A file that contains definitions of text analyzers. Works in combinations with --config-dir flag."]
+   [nil "--query-update-buffer-size NUMBER" "Number of queries to be buffered in memory before being committed to the queryindex. Default 100000."]
    ["-h" "--help"]])
 
 (defn handle-args [args]

--- a/src/lmgrep/lucene/monitor.clj
+++ b/src/lmgrep/lucene/monitor.clj
@@ -27,10 +27,11 @@
 
 (def default-analyzer (analyzer/create {}))
 
-(defn create [field-names-w-analyzers]
+(defn create [field-names-w-analyzers options]
   (let [^MonitorConfiguration config (MonitorConfiguration.)
         per-field-analyzers (PerFieldAnalyzerWrapper. default-analyzer field-names-w-analyzers)]
     (.setIndexPath config nil monitor-query-serializer)
+    (.setQueryUpdateBufferSize config (int (get options :query-update-buffer-size 100000)))
     (Monitor. per-field-analyzers config)))
 
 (defn defer-to-one-by-one-registration [^Monitor monitor monitor-queries]
@@ -66,7 +67,7 @@
   [questionnaire default-type options custom-analyzers]
   (let [questionnaire-with-analyzers (dictionary/normalize questionnaire default-type options custom-analyzers)
         mappings-from-field-names-to-analyzers (field-name-analyzer-mappings questionnaire-with-analyzers)
-        monitor (create mappings-from-field-names-to-analyzers)]
+        monitor (create mappings-from-field-names-to-analyzers options)]
     (register-queries monitor (dictionary/get-monitor-queries questionnaire-with-analyzers))
     {:monitor     monitor
      :field-names (keys mappings-from-field-names-to-analyzers)}))


### PR DESCRIPTION
To speed up creating the Monitor for large file with queries, we can increase the batch size. The default of 5000 is a bit too small for large batches.