### PR TITLE
Properly setup the GH Actions runner OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,9 @@ jobs:
             resources/LMGREP_VERSION
 
   build-native-executables-and-upload-to-release:
+    name: Native image build on ${{ matrix.os }}
     needs: [create-gh-release, build-uberjar-upload-to-release-and-store-artifacts]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]


### PR DESCRIPTION
Because the binaries build in the last release were build only for the linux 😮‍💨 