### PR TITLE
Fix unbounded blocking queue in only analyze with no preserve order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+## Fixed/enhanced
+
+- `--only-analyze` with `--no-preserve-order` prevent OOM
+- `--only-analyze` option `--queue-size` to specify the Java executor service queue size.
+
 ## v2022.02.10
 
 ## Fixed/enhanced

--- a/src/lmgrep/cli.clj
+++ b/src/lmgrep/cli.clj
@@ -5,7 +5,8 @@
 
 (defn prepare-analysis [options]
   (if (empty? (get-in options [:options :analysis]))
-    (assoc-in options [:options :analysis] (ac/prepare-analysis-configuration ac/default-text-analysis options))
+    (assoc-in options [:options :analysis]
+              (ac/prepare-analysis-configuration ac/default-text-analysis options))
     options))
 
 (defn remove-text-analysis-flags [options]
@@ -18,4 +19,8 @@
       (update-in [:options] remove-text-analysis-flags)))
 
 (comment
-  (lmgrep.cli/handle-args ["--tokenizer=standard" "--stem?=false" "--stemmer=english" "--case-sensitive?=true"]))
+  (lmgrep.cli/handle-args ["--tokenizer=standard"
+                           "--stem?=false"
+                           "--stemmer=english"
+                           "--case-sensitive?=true"])
+  (lmgrep.cli/handle-args ["--concurrency=1"]))

--- a/src/lmgrep/cli/parser.clj
+++ b/src/lmgrep/cli/parser.clj
@@ -102,7 +102,12 @@
     :parse-fn read-json]
    [nil "--concurrency CONCURRENCY" "How many concurrent threads to use for processing."
     :parse-fn #(Integer/parseInt %)
+    :validate [(fn [value] (< 0 value)) "Must be > 0"]
     :default 8]
+   [nil "--queue-size SIZE" "Number of lines read before being processed"
+    :parse-fn #(Integer/parseInt %)
+    :validate [(fn [value] (< 0 value)) "Must be > 0"]
+    :default 1024]
    [nil "--reader-buffer-size BUFFER_SIZE" "Buffer size of the BufferedReader in bytes."
     :parse-fn #(Integer/parseInt %)]
    [nil "--writer-buffer-size BUFFER_SIZE" "Buffer size of the BufferedWriter in bytes."


### PR DESCRIPTION
When heaps are small, e.g. -Xmx64m then an unbounded queue of the java executor service that stores lines of text to be analysed with cause lmgrep to throw OOM exception.

To prevent such errors expose a CLI param `--queue-size` with default 1024.