### PR TITLE
Print available text analysis components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Fixed/enhanced
 
 - `--only-analyze` with `--no-preserve-order` prevent OOM
-- `--only-analyze` option `--queue-size` to specify the Java executor service queue size.
+- `--only-analyze` option `--queue-size` to specify the Java executor service queue size
+- Flag `--show-analysis-components` to print out a list of available text analysis components
 
 ## v2022.02.10
 

--- a/src/lmgrep/cli/parser.clj
+++ b/src/lmgrep/cli/parser.clj
@@ -91,6 +91,8 @@
     :default false]
    [nil "--word-delimiter-graph-filter WDGF" "WordDelimiterGraphFilter configurationFlags as per https://lucene.apache.org/core/7_4_0/analyzers-common/org/apache/lucene/analysis/miscellaneous/WordDelimiterGraphFilter.html"
     :parse-fn #(Integer/parseInt %)]
+   [nil "--show-analysis-components" "Just print-out the available analysis components in JSON."
+    :default false]
    [nil "--only-analyze" "When provided output will be analyzed text."
     :default false]
    [nil "--explain" "Modifies --only-analyze. Output is detailed token info, similar to Elasticsearch Analyze API."]


### PR DESCRIPTION
e.g. `lmgrep --show-analysis-components | jq` prints
```
{
  "analyzers": [
    "arabic",
    "armenian",
    "basque",
    "bengali",
    "brazilian",
    "bulgarian",
    "catalan",
    "cjk",
    "classic",
    "collationkey",
    "czech",
    "danish",
    "dutch",
    "english",
    "estonian",
    "finnish",
    "french",
    "galician",
    "german",
    "greek",
    "hindi",
    "hungarian",
    "indonesian",
    "irish",
    "italian",
    "keyword",
    "latvian",
    "lithuanian",
    "norwegian",
    "persian",
    "polish",
    "portuguese",
    "romanian",
    "russian",
    "simple",
    "sorani",
    "spanish",
    "standard",
    "stop",
    "swedish",
    "thai",
    "turkish",
    "uax29urlemail",
    "unicodewhitespace",
    "whitespace"
  ],
  "char-filters": [
    "cjkwidth",
    "htmlstrip",
    "mapping",
    "patternreplace",
    "persian"
  ],
  "tokenizers": [
    "classic",
    "edgengram",
    "keyword",
    "letter",
    "ngram",
    "pathhierarchy",
    "pattern",
    "simplepattern",
    "simplepatternsplit",
    "standard",
    "thai",
    "uax29urlemail",
    "whitespace",
    "wikipedia"
  ],
  "token-filters": [
    "apostrophe",
    "arabicnormalization",
    "arabicstem",
    "armeniansnowballstem",
    "asciifolding",
    "basquesnowballstem",
    "bengalinormalization",
    "bengalistem",
    "brazilianstem",
    "bulgarianstem",
    "capitalization",
    "catalansnowballstem",
    "cjkbigram",
    "cjkwidth",
    "classic",
    "codepointcount",
    "commongrams",
    "commongramsquery",
    "concatenategraph",
    "czechstem",
    "danishsnowballstem",
    "daterecognizer",
    "decimaldigit",
    "delimitedboost",
    "delimitedpayload",
    "delimitedtermfrequency",
    "dictionarycompoundword",
    "dropifflagged",
    "dutchsnowballstem",
    "edgengram",
    "elision",
    "englishminimalstem",
    "englishpossessive",
    "estoniansnowballstem",
    "fingerprint",
    "finnishlightstem",
    "fixbrokenoffsets",
    "fixedshingle",
    "flattengraph",
    "frenchlightstem",
    "frenchminimalstem",
    "galicianminimalstem",
    "galicianstem",
    "germanlightstem",
    "germanminimalstem",
    "germannormalization",
    "germanstem",
    "greeklowercase",
    "greekstem",
    "hindinormalization",
    "hindistem",
    "hungarianlightstem",
    "hunspellstem",
    "hyphenatedwords",
    "hyphenationcompoundword",
    "indicnormalization",
    "indonesianstem",
    "irishlowercase",
    "irishsnowballstem",
    "italianlightstem",
    "keepword",
    "keywordmarker",
    "keywordrepeat",
    "kpsnowballstem",
    "kstem",
    "latvianstem",
    "length",
    "limittokencount",
    "limittokenoffset",
    "limittokenposition",
    "lithuaniansnowballstem",
    "lovinssnowballstem",
    "lowercase",
    "minhash",
    "ngram",
    "norwegianlightstem",
    "norwegianminimalstem",
    "norwegiannormalization",
    "numericpayload",
    "patterncapturegroup",
    "patternreplace",
    "patterntyping",
    "persiannormalization",
    "porterstem",
    "portugueselightstem",
    "portugueseminimalstem",
    "portuguesestem",
    "protectedterm",
    "removeduplicates",
    "reversestring",
    "romaniansnowballstem",
    "russianlightstem",
    "scandinavianfolding",
    "scandinaviannormalization",
    "serbiannormalization",
    "shingle",
    "snowballporter",
    "soraninormalization",
    "soranistem",
    "spanishlightstem",
    "spanishminimalstem",
    "stemmeroverride",
    "stempelpolishstem",
    "stop",
    "swedishlightstem",
    "swedishminimalstem",
    "synonym",
    "synonymgraph",
    "telugunormalization",
    "telugustem",
    "tokenoffsetpayload",
    "trim",
    "truncate",
    "turkishlowercase",
    "turkishsnowballstem",
    "type",
    "typeaspayload",
    "typeassynonym",
    "uppercase",
    "worddelimiter",
    "worddelimitergraph"
  ]
}
```