### PR TITLE
Optimize --only-analyse program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 - `--only-analyze` with `--no-preserve-order` prevent OOM
 - `--only-analyze` option `--queue-size` to specify the Java executor service queue size
 - Flag `--show-analysis-components` to print out a list of available text analysis components
+- `--only-analyze` with `--preserve-order` based on Java [ExecutorService](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ExecutorService.html)
 
 ## v2022.02.10
 

--- a/src/lmgrep/concurrent.clj
+++ b/src/lmgrep/concurrent.clj
@@ -1,0 +1,17 @@
+(ns lmgrep.concurrent
+  (:import (java.util.concurrent ExecutorService Executors
+                                 ThreadPoolExecutor ThreadPoolExecutor$CallerRunsPolicy
+                                 LinkedBlockingQueue TimeUnit)))
+
+(defn shutdown-thread-pool-executors [& executors]
+  (doseq [^ExecutorService executor executors]
+    (.shutdown executor)
+    (.awaitTermination executor 60 TimeUnit/SECONDS)))
+
+(defn thread-pool-executor [^Integer concurrency ^Integer queue-size]
+  (ThreadPoolExecutor.
+    concurrency concurrency
+    0 TimeUnit/MILLISECONDS
+    (LinkedBlockingQueue. queue-size)
+    (Executors/defaultThreadFactory)
+    (ThreadPoolExecutor$CallerRunsPolicy.)))

--- a/src/lmgrep/concurrent.clj
+++ b/src/lmgrep/concurrent.clj
@@ -8,6 +8,9 @@
     (.shutdown executor)
     (.awaitTermination executor 60 TimeUnit/SECONDS)))
 
+(defn single-thread-executor []
+  (Executors/newSingleThreadExecutor))
+
 (defn thread-pool-executor [^Integer concurrency ^Integer queue-size]
   (ThreadPoolExecutor.
     concurrency concurrency

--- a/src/lmgrep/only_analyze.clj
+++ b/src/lmgrep/only_analyze.clj
@@ -1,11 +1,10 @@
 (ns lmgrep.only-analyze
-  (:require [clojure.core.async :as a]
-            [jsonista.core :as json]
+  (:require [jsonista.core :as json]
             [lmgrep.analysis :as analysis]
+            [lmgrep.concurrent :as c]
             [lmgrep.fs :as fs]
             [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.text-analysis :as text-analysis]
-            [lmgrep.concurrent :as c])
+            [lmgrep.lucene.text-analysis :as text-analysis])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
            (org.apache.lucene.analysis Analyzer)
            (java.util.concurrent ExecutorService)))

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -2,7 +2,7 @@
   (:require [lmgrep.concurrent :as c]
             [lmgrep.matching :as matching])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
-           (java.util.concurrent Executors ExecutorService)
+           (java.util.concurrent ExecutorService)
            (lmgrep.matching LineNrStr)))
 
 (defn consume-reader
@@ -36,7 +36,7 @@
         with-empty-lines (get options :with-empty-lines)
         ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))
         ^ExecutorService matcher-thread-pool-executor (c/thread-pool-executor concurrency queue-size)
-        ^ExecutorService writer-thread-pool-executor (Executors/newSingleThreadExecutor)]
+        ^ExecutorService writer-thread-pool-executor (c/single-thread-executor)]
     (doseq [^String path (if (empty? file-paths-to-analyze)
                            [nil]                            ;; STDIN is an input
                            file-paths-to-analyze)]

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -1,22 +1,9 @@
 (ns lmgrep.unordered
-  (:require [lmgrep.matching :as matching])
+  (:require [lmgrep.concurrent :as c]
+            [lmgrep.matching :as matching])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
-           (java.util.concurrent ThreadPoolExecutor TimeUnit Executors LinkedBlockingQueue
-                                 ThreadPoolExecutor$CallerRunsPolicy ExecutorService)
+           (java.util.concurrent Executors ExecutorService)
            (lmgrep.matching LineNrStr)))
-
-(defn shutdown-thread-pool-executors [& executors]
-  (doseq [^ExecutorService executor executors]
-    (.shutdown executor)
-    (.awaitTermination executor 60 TimeUnit/SECONDS)))
-
-(defn thread-pool-executor [^Integer concurrency ^Integer queue-size]
-  (ThreadPoolExecutor.
-    concurrency concurrency
-    0 TimeUnit/MILLISECONDS
-    (LinkedBlockingQueue. queue-size)
-    (Executors/defaultThreadFactory)
-    (ThreadPoolExecutor$CallerRunsPolicy.)))
 
 (defn consume-reader
   "Given a Reader iterates over lines and sends them to the
@@ -48,7 +35,7 @@
         queue-size (get options :queue-size 1024)
         with-empty-lines (get options :with-empty-lines)
         ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))
-        ^ExecutorService matcher-thread-pool-executor (thread-pool-executor concurrency queue-size)
+        ^ExecutorService matcher-thread-pool-executor (c/thread-pool-executor concurrency queue-size)
         ^ExecutorService writer-thread-pool-executor (Executors/newSingleThreadExecutor)]
     (doseq [^String path (if (empty? file-paths-to-analyze)
                            [nil]                            ;; STDIN is an input
@@ -62,5 +49,5 @@
                                                               writer
                                                               with-empty-lines)]
         (consume-reader reader unordered-matcher-fn matcher-thread-pool-executor)))
-    (shutdown-thread-pool-executors matcher-thread-pool-executor writer-thread-pool-executor)
+    (c/shutdown-thread-pool-executors matcher-thread-pool-executor writer-thread-pool-executor)
     (.flush writer)))


### PR DESCRIPTION
Get rid of the core.async dependency by rewriting ordered analysis based on ExecutorService for `--only-analyze`.

~3x faster execution.