### PR TITLE
Remove clojure.tools.logging from the lmgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Fixed/enhanced
 
+- Fixed Windows release file name construction in Github Actions
+- Remove clojure.tools.logging
+
+## v2022.02.14
+
+## Fixed/enhanced
+
 - ~3x throughput improvements for matching!
 - `--only-analyze` with `--no-preserve-order` prevent OOM
 - `--only-analyze` option `--queue-size` to specify the Java executor service queue size

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,6 @@
  :deps
  {org.clojure/clojure                  {:mvn/version "1.10.3"}
   org.clojure/tools.cli                {:mvn/version "1.0.206"}
-  org.clojure/tools.logging            {:mvn/version "1.2.4"}
   org.apache.lucene/lucene-core        {:mvn/version "9.0.0"}
   org.apache.lucene/lucene-monitor     {:mvn/version "9.0.0"}
   org.apache.lucene/lucene-queries     {:mvn/version "9.0.0"}

--- a/src/lmgrep/cli/analysis_conf.clj
+++ b/src/lmgrep/cli/analysis_conf.clj
@@ -1,5 +1,4 @@
-(ns lmgrep.cli.analysis-conf
-  (:require [clojure.tools.logging :as log]))
+(ns lmgrep.cli.analysis-conf)
 
 (def analysis-keys #{:case-sensitive?
                      :ascii-fold?
@@ -68,7 +67,6 @@
             (not (zero? (bit-and wdgf 256))) (assoc "stemEnglishPossessive" 1)
             (not (zero? (bit-and wdgf 512))) (assoc "ignoreKeywords" 1))))
 
-
 (defn override-token-filters [token-filters flags]
   (cond->> token-filters
            (true? (get flags :case-sensitive?))
@@ -87,7 +85,8 @@
                                   stemmer-kw
                                   (do
                                     (when stemmer-kw
-                                      (log/debugf "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw))
+                                      (.println System/err
+                                                (format "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw)))
                                     "englishMinimalStem")))})))
            (pos-int? (get flags :word-delimiter-graph-filter))
            (cons {:name "worddelimitergraph"
@@ -100,7 +99,8 @@
                              tokenizer-kw
                              (do
                                (when tokenizer-kw
-                                 (log/debugf "Tokenizer '%s' not found. StandardTokenizer is used." tokenizer-kw))
+                                 (.println System/err
+                                           (format "Tokenizer '%s' not found. StandardTokenizer is used." tokenizer-kw)))
                                {:name "standard"})))
                       (:tokenizer acm))
         token-filters (override-token-filters (get acm :token-filters) flags)]


### PR DESCRIPTION
Not really needed, and removing it makes the resulting binary smaller.