### PR TITLE
Simplify output writing

### DIFF
--- a/src/lmgrep/cli/analysis_conf.clj
+++ b/src/lmgrep/cli/analysis_conf.clj
@@ -81,13 +81,12 @@
                                        (re-matches #".*[Ss]tem.*" (name (get token-filter :name))))
                                      token-filters))
                     {:name (let [stemmer-kw (keyword (get flags :stemmer))]
-                             (get stemmer
-                                  stemmer-kw
-                                  (do
-                                    (when stemmer-kw
-                                      (.println System/err
-                                                (format "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw)))
-                                    "englishMinimalStem")))})))
+                             (or (get stemmer stemmer-kw)
+                                 (do
+                                   (when stemmer-kw
+                                     (.println System/err
+                                               (format "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw)))
+                                   "englishMinimalStem")))})))
            (pos-int? (get flags :word-delimiter-graph-filter))
            (cons {:name "worddelimitergraph"
                   :args (wdgf->token-filter-args
@@ -95,14 +94,13 @@
 
 (defn override-acm [acm flags]
   (let [tokenizer (or (when-let [tokenizer-kw (get flags :tokenizer)]
-                        (get tokenizer
-                             tokenizer-kw
-                             (do
-                               (when tokenizer-kw
-                                 (.println System/err
-                                           (format "Tokenizer '%s' not found. StandardTokenizer is used." tokenizer-kw)))
-                               {:name "standard"})))
-                      (:tokenizer acm))
+                        (or (get tokenizer tokenizer-kw)
+                            (do
+                              (when tokenizer-kw
+                                (.println System/err
+                                          (format "Tokenizer '%s' not found. StandardTokenizer is used." tokenizer-kw)))
+                              {:name "standard"})))
+                      (get acm :tokenizer))
         token-filters (override-token-filters (get acm :token-filters) flags)]
     (assoc acm
       :tokenizer tokenizer

--- a/src/lmgrep/matching.clj
+++ b/src/lmgrep/matching.clj
@@ -13,7 +13,7 @@
         format (get options :format)
         scored? (or (get options :with-score) (get options :with-scored-highlights))]
     (fn [line-nr line]
-      (if-let [highlights (seq (highlighter-fn line highlight-opts))]
+      (when-let [highlights (seq (highlighter-fn line highlight-opts))]
         (let [details (cond-> {:line-number line-nr
                                :line        line}
                               file-path (assoc :file file-path)
@@ -23,5 +23,4 @@
             :edn (pr-str details)
             :json (json/write-value-as-string details)
             :string (formatter/string-output highlights details options)
-            (formatter/string-output highlights details options)))
-        ""))))
+            (formatter/string-output highlights details options)))))))

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -21,12 +21,12 @@
         (.execute matcher-thread-pool-executor
                   ^Runnable (fn []
                               (let [^String out-str (matcher-fn line-nr line)]
-                                (if (.equals "" out-str)
+                                (if out-str
+                                  (.execute writer-thread-pool-executor
+                                            ^Runnable (fn [] (.println writer out-str)))
                                   (when with-empty-lines
                                     (.execute writer-thread-pool-executor
-                                              ^Runnable (fn [] (.println writer out-str))))
-                                  (.execute writer-thread-pool-executor
-                                            ^Runnable (fn [] (.println writer out-str)))))))
+                                              ^Runnable (fn [] (.println writer out-str))))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn ordered-consume-reader
@@ -45,10 +45,10 @@
                          ^Callable (fn [] (matcher-fn line-nr line)))]
           (.execute writer-thread-pool-executor
                     ^Runnable (fn [] (let [out-str (.get f)]
-                                       (if (.equals "" out-str)
+                                       (if out-str
+                                         (.println writer out-str)
                                          (when with-empty-lines
-                                           (.println writer out-str))
-                                         (.println writer out-str))))))
+                                           (.println writer "")))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn grep [file-paths-to-analyze highlighter-fn options]


### PR DESCRIPTION
`nil` should signify that in the string there were no matches. 