### PR TITLE
Build time flag to build native-image without GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- `LMGREP_FEATURE_EPSILON_GC`: use [Epsilon GC](https://www.graalvm.org/22.0/reference-manual/native-image/MemoryManagement/) in the binary.
+
+## v2022.02.17
+
 ## Fixed/enhanced
 
-- Fixed Windows release file name construction in Github Actions
+- Fixed the Windows release file name construction in Github Actions
 - Remove clojure.tools.logging
 
 ## v2022.02.14

--- a/README.md
+++ b/README.md
@@ -609,6 +609,10 @@ Tools build also has a hard time building an uberjar.
 (export LMGREP_FEATURE_RAUDIKKO=true && bb generate-reflection-config && make build)
 ```
 
+## Environment variables
+
+Check the [docs](docs/env-vars.md).
+
 ## Future work
 
 - [ ] Optimize matching by [processing lines in batches](https://github.com/dainiusjocas/lucene-grep/issues/3)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -14,7 +14,7 @@
 
 `LMGREP_STATIC`: `true` instructs GraalVM native-image tool to build a [statically linked](https://www.graalvm.org/22.0/reference-manual/native-image/StaticImages/) binary, only for Linux. 
 `LMGREP_MUSL`: instructs GraalVM native-image to statically link against [musl-libc](https://musl.libc.org/), only for Linux.
-
+`LMGREP_FEATURE_EPSILON_GC`: use [Epsilon GC](https://www.graalvm.org/22.0/reference-manual/native-image/MemoryManagement/) in the binary.
 
 ## Runtime
 

--- a/script/compile
+++ b/script/compile
@@ -47,6 +47,10 @@ if [ "$LMGREP_FEATURE_CHARSETS" = "true" ]; then
   args+=("-H:+AddAllCharsets")
 fi
 
+if [ "$LMGREP_FEATURE_EPSILON_GC" = "true" ]; then
+  args+=("--gc=epsilon")
+fi
+
 "$GRAALVM_HOME/bin/native-image" "${args[@]}"
 
 #upx -7 -k lmgrep


### PR DESCRIPTION
- Smaller binary
- Less Memory required
- faster startup