### PR TITLE
Feat/streamed execution of queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 ## Unreleased
 
+- Streamed matching with a flag `--streamed`
+
+## v2022.02.18
+
 - Fixed flushing behaviour when consuming from STDIN in the ruby-percolator example.
 - `LMGREP_FEATURE_EPSILON_GC`: use [Epsilon GC](https://www.graalvm.org/22.0/reference-manual/native-image/MemoryManagement/) in the binary.
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Supported options:
       --config-dir DIR                          A base directory from which to load text analysis resources, e.g. synonym files. Default: current dir.
       --analyzers-file FILE                     A file that contains definitions of text analyzers. Works in combinations with --config-dir flag.
       --query-update-buffer-size NUMBER         Number of queries to be buffered in memory before being committed to the queryindex. Default 100000.
+      --streamed                                Listens on STDIN for json with both query and a piece of text to be analyzed
   -h, --help
 ```
 
@@ -595,9 +596,30 @@ Or MacOS:
 echo "FooBar-Baz" | ./lmgrep --word-delimiter-graph-filter=99 --only-analyze --graph | dot -Tpng | open -a Preview.app -f
 ```
 
+## Streamed matching
+
+Start `lmgrep` process once and wait for the input from STDIN that includes both: text and the query.
+Using such a technique avoids the "cold start" issues when with the stream of text the query is known only when the text is known.
+
+Example:
+
+```shell
+echo '{"query": "nike~", "text": "I am selling nikee"}' | ./lmgrep --streamed --with-score --format=json --query-parser=simple
+#=> {"line-number":1,"line":"I am selling nikee","score":0.09807344}
+```
+
+Is equivalent to:
+
+```shell
+echo  "I am selling nikee" | ./lmgrep --query="nike~" --with-score --format=json --query-parser=simple
+#=> {"line-number":1,"line":"I am selling nikee","score":0.09807344}
+```
+
+All other options are also applicable.
+
 ## Custom Builds
 
-## Raudikko or Voikko stemming for Finnish Language
+### Raudikko or Voikko stemming for Finnish Language
 
 NOTE: The project is re-architected in a way that Raudikko token filter definition is in the subdirectory.
 Also, it was put under the deps.edn alias.

--- a/src/lmgrep/cli/parser.clj
+++ b/src/lmgrep/cli/parser.clj
@@ -119,4 +119,5 @@
    [nil "--config-dir DIR" "A base directory from which to load text analysis resources, e.g. synonym files. Default: current dir."]
    [nil "--analyzers-file FILE" "A file that contains definitions of text analyzers. Works in combinations with --config-dir flag."]
    [nil "--query-update-buffer-size NUMBER" "Number of queries to be buffered in memory before being committed to the queryindex. Default 100000."]
+   [nil "--streamed" "Listens on STDIN for json with both query and a piece of text to be analyzed" :default false]
    ["-h" "--help"]])

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -43,7 +43,7 @@
             available-analysis-components))
         (System/exit 0))
       (when (get options :streamed)
-        (streamed/start options)
+        (streamed/grep options)
         (System/exit 0))
       (if (:only-analyze options)
         (analyze/analyze-lines (first positional-arguments) (rest positional-arguments) options)

--- a/src/lmgrep/lucene.clj
+++ b/src/lmgrep/lucene.clj
@@ -1,7 +1,9 @@
 (ns lmgrep.lucene
   (:require [clojure.string :as s]
             [lmgrep.lucene.matching :as matching]
-            [lmgrep.lucene.monitor :as monitor]))
+            [lmgrep.lucene.monitor :as monitor])
+  (:import (java.io Closeable)
+           (org.apache.lucene.monitor Monitor)))
 
 (defn highlighter
   ([questionnaire] (highlighter questionnaire {}))
@@ -13,6 +15,29 @@
        ([text] (matching/match-monitor text monitor field-names {}))
        ([text opts] (matching/match-monitor text monitor field-names opts))))))
 
+(defprotocol IMatcher
+  (match [this text] [this text opts]))
+
+(deftype LuceneMonitorMatcher [^Monitor monitor field-names]
+  IMatcher
+  (match [_ text]
+    (matching/match-monitor text monitor field-names {}))
+  (match [_ text opts]
+    (matching/match-monitor text monitor field-names opts))
+  Closeable
+  (close [_] (.close ^Monitor monitor)))
+
+(defn highlighter-obj
+  ([questionnaire] (highlighter-obj questionnaire {}))
+  ([questionnaire options] (highlighter-obj questionnaire options {}))
+  ([questionnaire {:keys [type-name] :as options} custom-analyzers]
+   (let [default-type (if (s/blank? type-name) "QUERY" type-name)
+         {:keys [monitor field-names]} (monitor/setup questionnaire default-type options custom-analyzers)]
+     (->LuceneMonitorMatcher monitor field-names))))
+
 (comment
   ((highlighter [{:query "text"}] {}) "foo text bar")
-  ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true}))
+  ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true})
+
+  (with-open [lm (highlighter-obj [{:query "text"}] {})]
+    (.match lm "foo text bar")))

--- a/src/lmgrep/matching.clj
+++ b/src/lmgrep/matching.clj
@@ -1,6 +1,7 @@
 (ns lmgrep.matching
   (:require [jsonista.core :as json]
-            [lmgrep.formatter :as formatter]))
+            [lmgrep.formatter :as formatter])
+  (:import (lmgrep.lucene LuceneMonitorMatcher)))
 
 (defn sum-score [highlights]
   (when-let [scores (seq (remove nil? (map :score highlights)))]
@@ -13,6 +14,24 @@
         scored? (or (get options :with-score) (get options :with-scored-highlights))]
     (fn [line-nr line]
       (when-let [highlights (seq (highlighter-fn line highlight-opts))]
+        (let [details (cond-> {:line-number line-nr
+                               :line        line}
+                              file-path (assoc :file file-path)
+                              (true? scored?) (assoc :score (sum-score highlights))
+                              (true? with-details?) (assoc :highlights highlights))]
+          (case format
+            :edn (pr-str details)
+            :json (json/write-value-as-string details)
+            :string (formatter/string-output highlights details options)
+            (formatter/string-output highlights details options)))))))
+
+(defn matcher-fn-2 [^LuceneMonitorMatcher highlighter-obj file-path options]
+  (let [highlight-opts (select-keys options [:with-score :with-scored-highlights])
+        with-details? (get options :with-details)
+        format (get options :format)
+        scored? (or (get options :with-score) (get options :with-scored-highlights))]
+    (fn [line-nr line]
+      (when-let [highlights (seq (.match highlighter-obj line highlight-opts))]
         (let [details (cond-> {:line-number line-nr
                                :line        line}
                               file-path (assoc :file file-path)

--- a/src/lmgrep/matching.clj
+++ b/src/lmgrep/matching.clj
@@ -7,7 +7,6 @@
     (reduce + scores)))
 
 (defn matcher-fn [highlighter-fn file-path options]
-  ;; This function can not return nil values
   (let [highlight-opts (select-keys options [:with-score :with-scored-highlights])
         with-details? (get options :with-details)
         format (get options :format)

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -13,10 +13,10 @@
         print-writer-buffer-size (get options :writer-buffer-size 8192)
         ^PrintWriter reader (BufferedReader. *in* reader-buffer-size)
         writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))
-        line-nr 1
         with-empty-lines (get options :with-empty-lines)]
     (with-open [^BufferedReader rdr reader]
-      (loop [^String line (.readLine rdr)]
+      (loop [^String line (.readLine rdr)
+             line-nr 1]
         (when-not (nil? line)
           (let [{:keys [query text]} (json/read-value line json/keyword-keys-object-mapper)
                 highlighter-fn (lucene/highlighter [{:query query}] options custom-analyzers)
@@ -25,5 +25,5 @@
               (.println writer out-str)
               (when with-empty-lines
                 (.println writer ""))))
-          (recur (.readLine rdr)))))
+          (recur (.readLine rdr) (inc line-nr)))))
     (.flush writer)))

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -87,5 +87,4 @@
                 writer writer-thread-pool-executor
                 with-empty-lines custom-analyzers options)
     (c/shutdown-thread-pool-executors matcher-thread-pool-executor writer-thread-pool-executor)
-    (Thread/sleep 100)
     (.flush writer)))

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -49,7 +49,7 @@
                                   (if out-str
                                     (.println writer out-str)
                                     (when with-empty-lines
-                                      (.println writer "")))))))
+                                      (.println writer)))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn grep

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -24,7 +24,8 @@
           query (get task "query")
           text (get task "text")]
       (when (and query text)
-        (with-open [^LuceneMonitorMatcher highlighter (lucene/highlighter-obj [{:query query}] options custom-analyzers)]
+        (with-open [^LuceneMonitorMatcher highlighter
+                    (lucene/highlighter-obj [{:query query}] options custom-analyzers)]
           ((matching/matcher-fn-2 highlighter nil options) line-nr text))))))
 
 (defn unordered [reader ^ExecutorService matcher-thread-pool-executor
@@ -68,8 +69,11 @@
   "Listens on STDIN where every line should include JSON with both: query and the text.
   Example input: {\"query\": \"nike~\", \"text\": \"I am selling nikee\"}
 
-  When a bad JSON string is passed then program doesn't crash.
-  First, ThreadPoolExecutor is async and it swallows Exceptions."
+  If either query or text is not present in the JSON, then matching is skipped.
+
+  When a bad JSON string is passed then program doesn't crash:
+    1. ThreadPoolExecutor is async and it 'swallows' Exceptions.
+    2. Upstream errors happen and we should handle them."
   [options]
   (let [custom-analyzers (analysis/prepare-analyzers (get options :analyzers-file) options)
         reader-buffer-size (get options :reader-buffer-size 8192)

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -6,13 +6,14 @@
   (:import (java.io BufferedReader BufferedWriter PrintWriter)))
 
 (defn start
-  "Listens on STDIN where every line should include both query and the text."
+  "Listens on STDIN where every line should include JSON with both: query and the text.
+  Example input: {\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
   [options]
   (let [custom-analyzers (analysis/prepare-analyzers (get options :analyzers-file) options)
         reader-buffer-size (get options :reader-buffer-size 8192)
         print-writer-buffer-size (get options :writer-buffer-size 8192)
-        ^PrintWriter reader (BufferedReader. *in* reader-buffer-size)
-        writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))
+        ^BufferedReader reader (BufferedReader. *in* reader-buffer-size)
+        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size) true)
         with-empty-lines (get options :with-empty-lines)]
     (with-open [^BufferedReader rdr reader]
       (loop [^String line (.readLine rdr)

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -2,10 +2,57 @@
   (:require [jsonista.core :as json]
             [lmgrep.lucene :as lucene]
             [lmgrep.analysis :as analysis]
-            [lmgrep.matching :as matching])
-  (:import (java.io BufferedReader BufferedWriter PrintWriter)))
+            [lmgrep.matching :as matching]
+            [lmgrep.concurrent :as c])
+  (:import (java.io BufferedReader BufferedWriter PrintWriter)
+           (java.util.concurrent ExecutorService)))
 
-(defn start
+(set! *warn-on-reflection* true)
+
+(defn unordered [reader ^ExecutorService matcher-thread-pool-executor
+                 ^PrintWriter writer ^ExecutorService writer-thread-pool-executor
+                 with-empty-lines custom-analyzers options]
+  (with-open [^BufferedReader rdr reader]
+    (loop [^String line (.readLine rdr)
+           line-nr 1]
+      (when-not (nil? line)
+        (.execute matcher-thread-pool-executor
+                  ^Runnable (fn []
+                              (let [{:keys [query text]} (json/read-value line json/keyword-keys-object-mapper)
+                                    highlighter-fn (lucene/highlighter [{:query query}] options custom-analyzers)
+                                    matcher-fn (matching/matcher-fn highlighter-fn nil options)
+                                    ^String out-str (matcher-fn line-nr text)]
+                                (if out-str
+                                  (.execute writer-thread-pool-executor
+                                            ^Runnable (fn [] (.println writer out-str)))
+                                  (when with-empty-lines
+                                    (.execute writer-thread-pool-executor
+                                              ^Runnable (fn [] (.println writer out-str))))))))
+        (recur (.readLine rdr) (inc line-nr))))))
+
+(defn ordered [reader ^ExecutorService matcher-thread-pool-executor
+               ^PrintWriter writer ^ExecutorService writer-thread-pool-executor
+               with-empty-lines custom-analyzers options]
+  (with-open [^BufferedReader rdr reader]
+    (loop [^String line (.readLine rdr)
+           line-nr 1]
+      (when-not (nil? line)
+        (let [f (.submit matcher-thread-pool-executor
+                         ^Callable (fn []
+                                     (let [{:keys [query text]} (json/read-value line json/keyword-keys-object-mapper)
+                                           highlighter-fn (lucene/highlighter [{:query query}] options custom-analyzers)
+                                           matcher-fn (matching/matcher-fn highlighter-fn nil options)]
+                                       (matcher-fn line-nr text))))]
+          (.execute writer-thread-pool-executor
+                    ^Runnable (fn []
+                                (let [^String out-str (.get f)]
+                                  (if out-str
+                                    (.println writer out-str)
+                                    (when with-empty-lines
+                                      (.println writer "")))))))
+        (recur (.readLine rdr) (inc line-nr))))))
+
+(defn grep
   "Listens on STDIN where every line should include JSON with both: query and the text.
   Example input: {\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
   [options]
@@ -14,17 +61,16 @@
         print-writer-buffer-size (get options :writer-buffer-size 8192)
         ^BufferedReader reader (BufferedReader. *in* reader-buffer-size)
         ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size) true)
-        with-empty-lines (get options :with-empty-lines)]
-    (with-open [^BufferedReader rdr reader]
-      (loop [^String line (.readLine rdr)
-             line-nr 1]
-        (when-not (nil? line)
-          (let [{:keys [query text]} (json/read-value line json/keyword-keys-object-mapper)
-                highlighter-fn (lucene/highlighter [{:query query}] options custom-analyzers)
-                matcher-fn (matching/matcher-fn highlighter-fn nil options)]
-            (if-let [out-str (matcher-fn line-nr text)]
-              (.println writer out-str)
-              (when with-empty-lines
-                (.println writer ""))))
-          (recur (.readLine rdr) (inc line-nr)))))
+        with-empty-lines (get options :with-empty-lines)
+        concurrency (get options :concurrency (.availableProcessors (Runtime/getRuntime)))
+        queue-size (get options :queue-size 1024)
+        ^ExecutorService matcher-thread-pool-executor (c/thread-pool-executor concurrency queue-size)
+        ^ExecutorService writer-thread-pool-executor (c/single-thread-executor)
+        preserve-order? (get options :preserve-order true)
+        consume-fn (if preserve-order? ordered unordered)]
+    (consume-fn reader matcher-thread-pool-executor
+                writer writer-thread-pool-executor
+                with-empty-lines custom-analyzers options)
+    (c/shutdown-thread-pool-executors matcher-thread-pool-executor writer-thread-pool-executor)
+    (Thread/sleep 100)
     (.flush writer)))

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -1,0 +1,29 @@
+(ns lmgrep.streamed
+  (:require [jsonista.core :as json]
+            [lmgrep.lucene :as lucene]
+            [lmgrep.analysis :as analysis]
+            [lmgrep.matching :as matching])
+  (:import (java.io BufferedReader BufferedWriter PrintWriter)))
+
+(defn start
+  "Listens on STDIN where every line should include both query and the text."
+  [options]
+  (let [custom-analyzers (analysis/prepare-analyzers (get options :analyzers-file) options)
+        reader-buffer-size (get options :reader-buffer-size 8192)
+        print-writer-buffer-size (get options :writer-buffer-size 8192)
+        ^PrintWriter reader (BufferedReader. *in* reader-buffer-size)
+        writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size))
+        line-nr 1
+        with-empty-lines (get options :with-empty-lines)]
+    (with-open [^BufferedReader rdr reader]
+      (loop [^String line (.readLine rdr)]
+        (when-not (nil? line)
+          (let [{:keys [query text]} (json/read-value line json/keyword-keys-object-mapper)
+                highlighter-fn (lucene/highlighter [{:query query}] options custom-analyzers)
+                matcher-fn (matching/matcher-fn highlighter-fn nil options)]
+            (if-let [out-str (matcher-fn line-nr text)]
+              (.println writer out-str)
+              (when with-empty-lines
+                (.println writer ""))))
+          (recur (.readLine rdr)))))
+    (.flush writer)))

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -26,7 +26,7 @@
                                             ^Runnable (fn [] (.println writer out-str)))
                                   (when with-empty-lines
                                     (.execute writer-thread-pool-executor
-                                              ^Runnable (fn [] (.println writer out-str))))))))
+                                              ^Runnable (fn [] (.println writer))))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn ordered-consume-reader
@@ -48,7 +48,7 @@
                                        (if out-str
                                          (.println writer out-str)
                                          (when with-empty-lines
-                                           (.println writer "")))))))
+                                           (.println writer)))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn grep [file-paths-to-analyze highlighter-fn options]

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -7,7 +7,8 @@
 (deftest grepping-file
   (let [file "test/resources/test.txt"
         query "fox"
-        options {:split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+        options {:preserve-order true
+                 :split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
     (is (= "The quick brown >fox< jumps over the lazy dog"
            (str/trim
              (with-out-str

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -88,4 +88,37 @@
              (with-in-str text-from-stdin
                           (str/trim
                             (with-out-str
-                              (streamed/grep options)))))))))
+                              (streamed/grep options))))))))
+
+  (testing "Testing JSON that doesn't contain the string"
+    (let [text-from-stdin "{\"query\": \"AND nike~\"}"
+          options {:preserve-order true
+                   :query-parser   "simple"
+                   :split          true}]
+      (is (empty?
+            (with-in-str
+              text-from-stdin
+              (with-out-str
+                (streamed/grep options)))))))
+
+  (testing "Testing JSON that doesn't contain query"
+    (let [text-from-stdin "{\"text\": \"I am selling nikee\"}"
+          options {:preserve-order true
+                   :query-parser   "simple"
+                   :split          true}]
+      (is (empty?
+            (with-in-str
+              text-from-stdin
+              (with-out-str
+                (streamed/grep options)))))))
+
+  (testing "Testing JSON that doesn't contain query"
+    (let [text-from-stdin "{}"
+          options {:preserve-order true
+                   :query-parser   "simple"
+                   :split          true}]
+      (is (empty?
+            (with-in-str
+              text-from-stdin
+              (with-out-str
+                (streamed/grep options))))))))

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -5,7 +5,19 @@
             [lmgrep.streamed :as streamed]))
 
 (deftest streamed-processing
-  (testing "Fuzzy match behaviour"
+  (testing "Fuzzy match behaviour ordered"
+    (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
+          options {:preserve-order true
+                   :split          true
+                   :pre-tags       ">" :post-tags "<"
+                   :template       "{{highlighted-line}}"}]
+      (is (= "I am selling >nikee<"
+             (with-in-str text-from-stdin
+                          (str/trim
+                            (with-out-str
+                              (streamed/grep options))))))))
+
+  (testing "Fuzzy match behaviour without preserving the order"
     (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
           options {:preserve-order false
                    :split          true
@@ -15,11 +27,11 @@
              (with-in-str text-from-stdin
                           (str/trim
                             (with-out-str
-                              (streamed/start options))))))))
+                              (streamed/grep options))))))))
 
   (testing "Fuzzy match behaviour with score"
     (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
-          options {:preserve-order false
+          options {:preserve-order true
                    :split          true
                    :pre-tags       ">" :post-tags "<"
                    :with-score     true
@@ -38,11 +50,11 @@
                (with-in-str text-from-stdin
                             (str/trim
                               (with-out-str
-                                (streamed/start options)))))))))
+                                (streamed/grep options)))))))))
 
   (testing "Fuzzy match behaviour with scored-highlights"
     (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
-          options {:preserve-order         false
+          options {:preserve-order         true
                    :split                  true
                    :pre-tags               ">" :post-tags "<"
                    :with-scored-highlights true
@@ -63,11 +75,11 @@
                (with-in-str text-from-stdin
                             (str/trim
                               (with-out-str
-                                (streamed/start options)))))))))
+                                (streamed/grep options)))))))))
 
   (testing "query parser params are working, AND at the start should throw an exception"
     (let [text-from-stdin "{\"query\": \"AND nike~\", \"text\": \"I am selling nikee\"}"
-          options {:preserve-order false
+          options {:preserve-order true
                    :query-parser   "simple"
                    :split          true
                    :pre-tags       ">" :post-tags "<"
@@ -76,4 +88,4 @@
              (with-in-str text-from-stdin
                           (str/trim
                             (with-out-str
-                              (streamed/start options)))))))))
+                              (streamed/grep options)))))))))

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -1,0 +1,79 @@
+(ns lmgrep.streamed-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [jsonista.core :as json]
+            [lmgrep.streamed :as streamed]))
+
+(deftest streamed-processing
+  (testing "Fuzzy match behaviour"
+    (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
+          options {:preserve-order false
+                   :split          true
+                   :pre-tags       ">" :post-tags "<"
+                   :template       "{{highlighted-line}}"}]
+      (is (= "I am selling >nikee<"
+             (with-in-str text-from-stdin
+                          (str/trim
+                            (with-out-str
+                              (streamed/start options))))))))
+
+  (testing "Fuzzy match behaviour with score"
+    (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
+          options {:preserve-order false
+                   :split          true
+                   :pre-tags       ">" :post-tags "<"
+                   :with-score     true
+                   :with-details   true
+                   :format         :json}
+          expected {"highlights"  [{"dict-entry-id" "636317675"
+                                    "meta"          {}
+                                    "query"         "nike~"
+                                    "score"         0.09807344
+                                    "type"          "QUERY"}]
+                    "line"        "I am selling nikee"
+                    "line-number" 1
+                    "score"       0.09807344}]
+      (is (= expected
+             (json/read-value
+               (with-in-str text-from-stdin
+                            (str/trim
+                              (with-out-str
+                                (streamed/start options)))))))))
+
+  (testing "Fuzzy match behaviour with scored-highlights"
+    (let [text-from-stdin "{\"query\": \"nike~\", \"text\": \"I am selling nikee\"}"
+          options {:preserve-order         false
+                   :split                  true
+                   :pre-tags               ">" :post-tags "<"
+                   :with-scored-highlights true
+                   :with-details           true
+                   :format                 :json}
+          expected {"highlights"  [{"begin-offset"  13
+                                    "dict-entry-id" "636317675"
+                                    "end-offset"    18
+                                    "meta"          {}
+                                    "query"         "nike~"
+                                    "score"         0.09807344
+                                    "type"          "QUERY"}]
+                    "line"        "I am selling nikee"
+                    "line-number" 1
+                    "score"       0.09807344}]
+      (is (= expected
+             (json/read-value
+               (with-in-str text-from-stdin
+                            (str/trim
+                              (with-out-str
+                                (streamed/start options)))))))))
+
+  (testing "query parser params are working, AND at the start should throw an exception"
+    (let [text-from-stdin "{\"query\": \"AND nike~\", \"text\": \"I am selling nikee\"}"
+          options {:preserve-order false
+                   :query-parser   "simple"
+                   :split          true
+                   :pre-tags       ">" :post-tags "<"
+                   :template       "{{highlighted-line}}"}]
+      (is (= "I am selling >nikee<"
+             (with-in-str text-from-stdin
+                          (str/trim
+                            (with-out-str
+                              (streamed/start options)))))))))

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -90,35 +90,59 @@
                             (with-out-str
                               (streamed/grep options))))))))
 
-  (testing "Testing JSON that doesn't contain the string"
-    (let [text-from-stdin "{\"query\": \"AND nike~\"}"
-          options {:preserve-order true
-                   :query-parser   "simple"
-                   :split          true}]
-      (is (empty?
-            (with-in-str
-              text-from-stdin
-              (with-out-str
-                (streamed/grep options)))))))
+  (doseq [options [{:preserve-order true
+                    :query-parser   "simple"
+                    :split          true}
 
-  (testing "Testing JSON that doesn't contain query"
-    (let [text-from-stdin "{\"text\": \"I am selling nikee\"}"
-          options {:preserve-order true
-                   :query-parser   "simple"
-                   :split          true}]
-      (is (empty?
-            (with-in-str
-              text-from-stdin
-              (with-out-str
-                (streamed/grep options)))))))
+                   {:preserve-order false
+                    :query-parser   "simple"
+                    :split          true}]]
 
-  (testing "Testing JSON that doesn't contain query"
-    (let [text-from-stdin "{}"
-          options {:preserve-order true
-                   :query-parser   "simple"
-                   :split          true}]
-      (is (empty?
-            (with-in-str
-              text-from-stdin
-              (with-out-str
-                (streamed/grep options))))))))
+    (testing "JSON that doesn't contain the text"
+      (let [text-from-stdin "{\"query\": \"AND nike~\"}"]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))
+
+
+    (testing "JSON that doesn't contain query"
+      (let [text-from-stdin "{\"text\": \"I am selling nikee\"}"]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))
+
+    (testing "JSON that doesn't contain neither query nor text"
+      (let [text-from-stdin "{}"]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))
+
+    (testing "invalid JSON"
+      (let [text-from-stdin "{\"query\": \"AND nike~\", \"text\": \"I am selling nikee\""]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))
+
+    (testing "when query and text are empty strings"
+      (let [text-from-stdin "{\"query\": \"\", \"text\": \"\"}"]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))
+
+    (testing "when query and text are nils"
+      (let [text-from-stdin "{\"query\": null, \"text\": null}"]
+        (is (empty?
+              (with-in-str
+                text-from-stdin
+                (with-out-str
+                  (streamed/grep options)))))))))


### PR DESCRIPTION
Start `lmgrep` process once and wait for the input from STDIN that includes both: text and the query. 
Using such a technique avoids the "cold start" issues when the query is known only when the text is known.

Example:
```
echo '{"query": "nike~", "text": "I am selling nikee"}' | ./lmgrep --streamed --with-score --format=json --query-parser=simple
#=> {"line-number":1,"line":"I am selling nikee","score":0.09807344}
```
Is equivalent to:
```
echo  "I am selling nikee" | ./lmgrep --query="nike~" --with-score --format=json --query-parser=simple
#=> {"line-number":1,"line":"I am selling nikee","score":0.09807344}
```