### PR TITLE
Feat/analyzer conf validation

### DIFF
--- a/src/lmgrep/lucene/custom_analyzer.clj
+++ b/src/lmgrep/lucene/custom_analyzer.clj
@@ -88,7 +88,7 @@
              (format "Token filters should be a list, was '%s'" token-filters))
 
      (assert (or (nil? tokenizer) (map? tokenizer))
-             (format "Tokenizer must have 'name' and 'args', but was '%s'" tokenizer))
+             (format "Tokenizer must have 'name' and optional 'args', but was '%s'" tokenizer))
      (.withTokenizer builder
                      ^Class (get-component-or-exception tokenizer-factories
                                                         (get tokenizer :name DEFAULT_TOKENIZER_NAME)
@@ -98,7 +98,7 @@
 
      (doseq [{:keys [name args] :as char-filter} char-filters]
        (assert (or (nil? char-filter) (map? char-filter))
-               (format "Character filter must have 'name' and 'args', but was '%s'" char-filter))
+               (format "Character filter must have 'name' and optional 'args', but was '%s'" char-filter))
        (.addCharFilter builder
                        ^Class (get-component-or-exception char-filter-factories
                                                           name
@@ -108,7 +108,7 @@
 
      (doseq [{:keys [name args] :as token-filter} token-filters]
        (assert (or (nil? token-filter) (map? token-filter))
-               (format "Token filter must have 'name' and 'args', but was '%s'" token-filter))
+               (format "Token filter must have 'name' and optional 'args', but was '%s'" token-filter))
        (.addTokenFilter builder
                         ^Class (get-component-or-exception token-filter-factories
                                                            name

--- a/src/lmgrep/lucene/custom_analyzer.clj
+++ b/src/lmgrep/lucene/custom_analyzer.clj
@@ -3,25 +3,29 @@
            (java.io File)
            (java.nio.file Path)
            (org.apache.lucene.analysis.custom CustomAnalyzer CustomAnalyzer$Builder)
-           (org.apache.lucene.analysis Analyzer TokenizerFactory CharFilterFactory TokenFilterFactory)))
+           (org.apache.lucene.analysis Analyzer CharFilterFactory TokenFilterFactory TokenizerFactory)))
 
-(defn stringify [m]
+(defn- stringify [m]
   (reduce-kv (fn [acc k v] (assoc acc (name k) (str v))) {} m))
 
-(def tokenizer-name->class
+(defn load-tokenizer-factories []
   (reduce (fn [acc ^String tokenizer-name]
             (assoc acc tokenizer-name (TokenizerFactory/lookupClass tokenizer-name)))
           {} (TokenizerFactory/availableTokenizers)))
 
-(def char-filter-name->class
+(defn load-char-filter-factories []
   (reduce (fn [acc ^String char-filter-name]
             (assoc acc char-filter-name (CharFilterFactory/lookupClass char-filter-name)))
           {} (CharFilterFactory/availableCharFilters)))
 
-(def token-filter-name->class
+(defn load-token-filter-factories []
   (reduce (fn [acc ^String token-filter-name]
             (assoc acc token-filter-name (TokenFilterFactory/lookupClass token-filter-name)))
           {} (TokenFilterFactory/availableTokenFilters)))
+
+(def tokenizer-name->class (load-tokenizer-factories))
+(def char-filter-name->class (load-char-filter-factories))
+(def token-filter-name->class (load-token-filter-factories))
 
 (def DEFAULT_TOKENIZER_NAME "standard")
 
@@ -39,6 +43,35 @@
                   (sort (keys factories)))))))
 
 (defn create
+  "Constructs a Lucene Analyzer using the CustomAnalyzer builder.
+   Under the hood it uses the factory classes TokenizerFactory, TokenFilterFactory, and CharFilterFactory.
+   The factories are loaded with java.util.ServiceLoader.
+
+   Factory description is of shape:
+   `
+   {:name String
+    :args Map}
+   `
+
+   If needed factories can be passed as arguments in shape:
+   `
+   {STRING CLASS}
+   `
+
+   Example:
+   `
+   {:tokenizer {:name \"standard\", :args {:maxTokenLength 4}}
+    :char-filters [{:name \"patternReplace\" :args {:pattern \"foo\", :replacement \"foo\"}}]
+    :token-filters [{:name \"uppercase\"} {:name \"reverseString\"}]
+    :config-dir \".\"}
+   `
+
+   `opts` can have specified:
+     - config-dir: path to directory from which resources will be loaded, default '.'
+     - char-filters: list of char filter descriptions
+     - tokenizer: tokenizer description, default 'standard' tokenizer
+     - token-filters: list of token filter descriptions
+     - namify-fn: function that changes the string identifier of the service name, e.g. str/lowercase, default: identity"
   (^Analyzer [opts]
    (create opts char-filter-name->class tokenizer-name->class token-filter-name->class))
   (^Analyzer [{:keys [config-dir char-filters tokenizer token-filters namify-fn]}
@@ -90,10 +123,4 @@
                      :args {:pattern "foo"
                             :replacement "foo"}}]
      :token-filters [{:name "uppercase"}
-                     {:name "reverseString"}]})
-
-  (lmgrep.lucene.custom-analyzer/create
-    {:tokenizer {:name "standard"}
-     :char-filters [{:name "patternReplace"
-                     :args {:pattern "foo"
-                            :replacement "bar"}}]}))
+                     {:name "reverseString"}]}))

--- a/src/lmgrep/lucene/custom_analyzer.clj
+++ b/src/lmgrep/lucene/custom_analyzer.clj
@@ -71,10 +71,13 @@
      - char-filters: list of char filter descriptions
      - tokenizer: tokenizer description, default 'standard' tokenizer
      - token-filters: list of token filter descriptions
+     - position-increment-gap: specify position increment gap
+     - offset-gap: specify offset gap
      - namify-fn: function that changes the string identifier of the service name, e.g. str/lowercase, default: identity"
   (^Analyzer [opts]
    (create opts char-filter-name->class tokenizer-name->class token-filter-name->class))
-  (^Analyzer [{:keys [config-dir char-filters tokenizer token-filters namify-fn]}
+  (^Analyzer [{:keys [config-dir char-filters tokenizer token-filters namify-fn
+                      position-increment-gap offset-gap]}
               char-filter-factories tokenizer-factories token-filter-factories]
    (let [namify-fn (or namify-fn identity)
          ^CustomAnalyzer$Builder builder (CustomAnalyzer/builder ^Path (config-dir->path config-dir))]
@@ -112,6 +115,11 @@
                                                            "Token filter"
                                                            namify-fn)
                         ^Map (HashMap. ^Map (stringify args))))
+
+     (when position-increment-gap
+       (.withPositionIncrementGap builder position-increment-gap))
+     (when offset-gap
+       (.withOffsetGap builder offset-gap))
 
      (.build builder))))
 

--- a/src/lmgrep/lucene/custom_analyzer.clj
+++ b/src/lmgrep/lucene/custom_analyzer.clj
@@ -45,6 +45,14 @@
               char-filter-factories tokenizer-factories token-filter-factories]
    (let [namify-fn (or namify-fn identity)
          ^CustomAnalyzer$Builder builder (CustomAnalyzer/builder ^Path (config-dir->path config-dir))]
+
+     (assert (or (nil? char-filters) (sequential? char-filters))
+             (format "Character filters should be a list, was '%s'" char-filters))
+     (assert (or (nil? token-filters) (sequential? token-filters))
+             (format "Token filters should be a list, was '%s'" token-filters))
+
+     (assert (or (nil? tokenizer) (map? tokenizer))
+             (format "Tokenizer must have 'name' and 'args', but was '%s'" tokenizer))
      (.withTokenizer builder
                      ^Class (get-component-or-exception tokenizer-factories
                                                         (get tokenizer :name DEFAULT_TOKENIZER_NAME)
@@ -52,7 +60,9 @@
                                                         namify-fn)
                      ^Map (HashMap. ^Map (stringify (get tokenizer :args))))
 
-     (doseq [{:keys [name args]} char-filters]
+     (doseq [{:keys [name args] :as char-filter} char-filters]
+       (assert (or (nil? char-filter) (map? char-filter))
+               (format "Character filter must have 'name' and 'args', but was '%s'" char-filter))
        (.addCharFilter builder
                        ^Class (get-component-or-exception char-filter-factories
                                                           name
@@ -60,7 +70,9 @@
                                                           namify-fn)
                        ^Map (HashMap. ^Map (stringify args))))
 
-     (doseq [{:keys [name args]} token-filters]
+     (doseq [{:keys [name args] :as token-filter} token-filters]
+       (assert (or (nil? token-filter) (map? token-filter))
+               (format "Token filter must have 'name' and 'args', but was '%s'" token-filter))
        (.addTokenFilter builder
                         ^Class (get-component-or-exception token-filter-factories
                                                            name
@@ -75,7 +87,7 @@
     {:tokenizer {:name "standard"
                  :args {:maxTokenLength 4}}
      :char-filters [{:name "patternReplace"
-                     :args {:pattern "joc"
+                     :args {:pattern "foo"
                             :replacement "foo"}}]
      :token-filters [{:name "uppercase"}
                      {:name "reverseString"}]})

--- a/test/lmgrep/lucene/custom_analyzer_test.clj
+++ b/test/lmgrep/lucene/custom_analyzer_test.clj
@@ -1,0 +1,65 @@
+(ns lmgrep.lucene.custom-analyzer-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [lmgrep.lucene.custom-analyzer :as analyzer]))
+
+(deftest custom-analyzer-validation
+  (testing "tokenizer config"
+    (let [tokenizer-config-as-string "FAIL"]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:tokenizer tokenizer-config-as-string}))))
+
+    (let [arrays-are-not-allowed []]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:tokenizer arrays-are-not-allowed})))))
+
+  (testing "char filter config should be sequable"
+    (let [hashmaps-are-not-allowed {}]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:char-filters hashmaps-are-not-allowed}))))
+
+    (let [strings-are-not-allowed "foo"]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:char-filters strings-are-not-allowed})))))
+
+  (testing "individual char-filter configuration"
+    (let [char-filter-config-as-string "FAIL"]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:char-filters [char-filter-config-as-string]}))))
+
+    (let [vector-filter-config-as-string ["FAIL"]]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:char-filters [vector-filter-config-as-string]})))))
+
+  (testing "token filter config should be sequable"
+    (let [hashmaps-are-not-allowed {}]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:token-filters hashmaps-are-not-allowed}))))
+
+    (let [strings-are-not-allowed "foo"]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:token-filters strings-are-not-allowed})))))
+
+  (testing "individual token-filter configuration"
+    (let [token-filter-config-as-string "FAIL"]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:token-filters [token-filter-config-as-string]}))))
+
+    (let [vector-token-filter-config ["FAIL"]]
+      (is (thrown? AssertionError
+                   (analyzer/create
+                     {:token-filters [vector-token-filter-config]})))))
+
+  (testing "invalid arguments passed throws an Exception"
+    (is (thrown? IllegalArgumentException
+                 (analyzer/create
+                   {:tokenizer {:name "standard"
+                                :args {:foo "foo"}}})))))


### PR DESCRIPTION
The format 
```
{:name ""
 :args {}}
```

Is chosen because it makes it easier to read from json file.