### PR TITLE
Refactor/short notation for custom analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ pom.xml.asc
 .lsp
 lmgrep-*.zip
 lmgrep.build_artifacts.txt
-lucene-grep.iml
+**.iml
 .musl

--- a/modules/custom-analyzer/README.md
+++ b/modules/custom-analyzer/README.md
@@ -16,19 +16,28 @@ Code:
 (require '[lmgrep.lucene.custom-analyzer :as custom-analyzer])
 
 (custom-analyzer/create
-  {:tokenizer              {:name "standard"
-                            :args {:maxTokenLength 4}}
-   :char-filters           [{:name "patternReplace"
-                             :args {:pattern     "foo"
-                                    :replacement "foo"}}]
-   :token-filters          [{:name "uppercase"}
-                            {:name "reverseString"}]
+  {:tokenizer              {:standard {:maxTokenLength 4}}
+   :char-filters           [{:patternReplace {:pattern     "foo"
+                                              :replacement "foo"}}]
+   :token-filters          [{:uppercase nil}
+                            {:reverseString nil}]
    :offset-gap             2
-   :position-increment-gap 3})
+   :position-increment-gap 3
+   :config-dir             "."})
 ;; =>
 ;; #object[org.apache.lucene.analysis.custom.CustomAnalyzer
 ;;         0x4686f87d
 ;;         "CustomAnalyzer(org.apache.lucene.analysis.pattern.PatternReplaceCharFilterFactory@2f1300,org.apache.lucene.analysis.standard.StandardTokenizerFactory@7e71a244,org.apache.lucene.analysis.core.UpperCaseFilterFactory@54e9f0d6,org.apache.lucene.analysis.reverse.ReverseStringFilterFactory@3e494ba7)"]
+```
+
+If nothing is provided then an Anlyzer with just the standard tokenizer is created:
+
+```clojure
+(custom-analyzer/create {})
+;; =>
+;; #object[org.apache.lucene.analysis.custom.CustomAnalyzer
+;;         0x456fe86
+;;         "CustomAnalyzer(org.apache.lucene.analysis.standard.StandardTokenizerFactory@5703f5b3)"]
 ```
 
 ## Design

--- a/modules/custom-analyzer/test/lmgrep/lucene/custom_analyzer_exceptions_test.clj
+++ b/modules/custom-analyzer/test/lmgrep/lucene/custom_analyzer_exceptions_test.clj
@@ -27,7 +27,7 @@
 
   (testing "individual char-filter configuration"
     (let [char-filter-config-as-string "FAIL"]
-      (is (thrown? AssertionError
+      (is (thrown? Exception
                    (analyzer/create
                      {:char-filters [char-filter-config-as-string]}))))
 
@@ -49,7 +49,7 @@
 
   (testing "individual token-filter configuration"
     (let [token-filter-config-as-string "FAIL"]
-      (is (thrown? AssertionError
+      (is (thrown? Exception
                    (analyzer/create
                      {:token-filters [token-filter-config-as-string]}))))
 
@@ -61,5 +61,4 @@
   (testing "invalid arguments passed throws an Exception"
     (is (thrown? IllegalArgumentException
                  (analyzer/create
-                   {:tokenizer {:name "standard"
-                                :args {:foo "foo"}}})))))
+                   {:tokenizer {"standard" {:foo "foo"}}})))))

--- a/modules/custom-analyzer/test/lmgrep/lucene/custom_analyzer_test.clj
+++ b/modules/custom-analyzer/test/lmgrep/lucene/custom_analyzer_test.clj
@@ -10,40 +10,40 @@
 
 (deftest analyzer-building
   (testing "tokenizer params handling"
-    (let [analyzer (a/create {:tokenizer {:name "standard"}})]
+    (let [analyzer (a/create {:tokenizer {"standard" nil}})]
       (is (instance? Analyzer analyzer))
       (is (instance? CustomAnalyzer analyzer))
       (is (= StandardTokenizerFactory
              (class (.getTokenizerFactory ^CustomAnalyzer analyzer)))))
 
-    (let [analyzer (a/create {:tokenizer {:name "keyword"}})]
+    (let [analyzer (a/create {:tokenizer {"keyword" nil}})]
       (is (= KeywordTokenizerFactory
              (class (.getTokenizerFactory ^CustomAnalyzer analyzer))))))
 
   (testing "char filter params handling"
-    (let [analyzer (a/create {:char-filters [{:name "htmlStrip"}]})]
+    (let [analyzer (a/create {:char-filters [{"htmlStrip" nil}]})]
       (is (= 1 (count (.getCharFilterFactories ^CustomAnalyzer analyzer))))
       (is (= HTMLStripCharFilterFactory
              (class (first (.getCharFilterFactories ^CustomAnalyzer analyzer))))))
 
-    (let [analyzer (a/create {:char-filters [{:name "htmlStrip"} {:name "htmlStrip"}]})]
+    (let [analyzer (a/create {:char-filters [{"htmlStrip" nil} {"htmlStrip" nil}]})]
       (is (= 2 (count (.getCharFilterFactories ^CustomAnalyzer analyzer))))
       (is (= [HTMLStripCharFilterFactory HTMLStripCharFilterFactory]
              (map #(class %) (.getCharFilterFactories ^CustomAnalyzer analyzer))))))
 
   (testing "token filter params handling"
-    (let [analyzer (a/create {:token-filters [{:name "asciiFolding"}]})]
+    (let [analyzer (a/create {:token-filters [{"asciiFolding" nil}]})]
       (is (= 1 (count (.getTokenFilterFactories ^CustomAnalyzer analyzer))))
       (is (= [ASCIIFoldingFilterFactory]
              (map #(class %) (.getTokenFilterFactories ^CustomAnalyzer analyzer)))))
 
-    (let [analyzer (a/create {:token-filters [{:name "asciiFolding"} {:name "lowercase"}]})]
+    (let [analyzer (a/create {:token-filters [{"asciiFolding" nil} {"lowercase" nil}]})]
       (is (= 2 (count (.getTokenFilterFactories ^CustomAnalyzer analyzer))))
       (is (= [ASCIIFoldingFilterFactory LowerCaseFilterFactory]
              (map #(class %) (.getTokenFilterFactories ^CustomAnalyzer analyzer))))))
 
   (testing "gap param handling"
-    (let [^CustomAnalyzer analyzer (a/create {:offset-gap 12
+    (let [^CustomAnalyzer analyzer (a/create {:offset-gap              12
                                               :position-increment-gap 3})]
       (is (= 12 (.getOffsetGap analyzer "")))
       (is (= 3 (.getPositionIncrementGap analyzer ""))))))

--- a/src/lmgrep/lucene/analyzer.clj
+++ b/src/lmgrep/lucene/analyzer.clj
@@ -31,6 +31,16 @@
                   analyzer-name
                   (sort (keys custom-analyzers)))))))
 
+
+(defn custom-analyzer->short-notation [conf]
+  (let [old->new (fn [old] {(get old :name) (get old :args)})
+        converted-tokenizer {(get-in conf [:tokenizer :name]) (get-in conf [:tokenizer :args])}
+        converted-char-filters (mapv old->new (get conf :char-filters))
+        converted-token-filters (mapv old->new (get conf :token-filters))]
+    (assoc conf :tokenizer converted-tokenizer
+                :char-filters converted-char-filters
+                :token-filters converted-token-filters)))
+
 (defn ^Analyzer create
   "Either fetches a predefined analyzer or creates one from the config."
   ([opts] (create opts {}))
@@ -38,7 +48,7 @@
    (try
      (if-let [analyzer-name (get analyzer :name)]
        (get-analyzer analyzer-name custom-analyzers)
-       (ca/create (assoc opts :namify-fn namify)
+       (ca/create (custom-analyzer->short-notation (assoc opts :namify-fn namify))
                   char-filter-name->class
                   tokenizer-name->class
                   token-filter-name->class))

--- a/test/lmgrep/lucene/analysis_test.clj
+++ b/test/lmgrep/lucene/analysis_test.clj
@@ -10,6 +10,22 @@
 (defn with-analyzers [opts]
   (analysis/create opts predefined/analyzers))
 
+(deftest converter
+  (let [conf {:tokenizer {:name "standard"
+                          :args {:maxTokenLength 4}}
+              :char-filters [{:name "patternReplace"
+                              :args {:pattern "foo"
+                                     :replacement "foo"}}]
+              :token-filters [{:name "uppercase"}
+                              {:name "reverseString"}]}
+
+        expected {:tokenizer {"standard" {:maxTokenLength 4}}
+                  :char-filters [{"patternReplace" {:pattern "foo"
+                                                    :replacement "foo"}}]
+                  :token-filters [{"uppercase" nil}
+                                  {"reverseString" nil}]}]
+    (is (= expected (analysis/custom-analyzer->short-notation conf)))))
+
 (when lmgrep.features/bundled?
   (deftest predefined-analyzers
     (let [text "The brown foxes"


### PR DESCRIPTION
```clojure
(require '[lmgrep.lucene.custom-analyzer :as custom-analyzer])

(custom-analyzer/create
  {:tokenizer              {:standard {:maxTokenLength 4}}
   :char-filters           [{:patternReplace {:pattern     "foo"
                                              :replacement "foo"}}]
   :token-filters          [{:uppercase nil}
                            {:reverseString nil}]
   :offset-gap             2
   :position-increment-gap 3
   :config-dir             "."})
;; =>
;; #object[org.apache.lucene.analysis.custom.CustomAnalyzer
;;         0x4686f87d
;;         "CustomAnalyzer(org.apache.lucene.analysis.pattern.PatternReplaceCharFilterFactory@2f1300,org.apache.lucene.analysis.standard.StandardTokenizerFactory@7e71a244,org.apache.lucene.analysis.core.UpperCaseFilterFactory@54e9f0d6,org.apache.lucene.analysis.reverse.ReverseStringFilterFactory@3e494ba7)"]
```