### PR TITLE
fix: file-oriented grepping on --no-split flag

### DIFF
--- a/src/lmgrep/formatter.clj
+++ b/src/lmgrep/formatter.clj
@@ -1,38 +1,64 @@
 (ns lmgrep.formatter
-  (:require [lmgrep.ansi-escapes :as ansi]
-            [clojure.string :as str]
-            [clojure.java.io :as io]))
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]
+            [lmgrep.ansi-escapes :as ansi]))
 
-(defn highlight-line
+(defn cutout-highlight [^String input-text highlights options]
+  (let [highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                       #(str (:pre-tags options) % (:post-tags options))
+                       ansi/red-text)]
+    (->> highlights
+         (mapv (fn [highlight]
+                 (let [prefix (subs input-text
+                                    (max 0 (- (:begin-offset highlight) 20))
+                                    (:begin-offset highlight))
+                       suffix (subs input-text
+                                    (:end-offset highlight)
+                                    (min (+ (:end-offset highlight) 20) (.length input-text)))
+                       matched-text (highlight-fn
+                                      (subs input-text
+                                            (:begin-offset highlight)
+                                            (:end-offset highlight)))
+                       ; Matching over the \newline is now possible
+                       resp (str/replace (str prefix matched-text suffix) "\n" " ")]
+                   resp)))
+         (str/join "\n"))))
+
+(defn highlight-line [line-str highlights options]
+  (let [highlights (sort-by :begin-offset highlights)
+        highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
+                       #(str (:pre-tags options) % (:post-tags options))
+                       ansi/red-text)]
+    (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
+           acc ""
+           last-position 0]
+      (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
+            highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
+                        (if (< (:begin-offset ann) last-position)
+                          ; adjusting highlight text for overlap
+                          (highlight-fn (subs text-to-highlight (min (.length text-to-highlight)
+                                                                     (- last-position (:begin-offset ann)))))
+                          (highlight-fn text-to-highlight)))
+            suffix (if (nil? next-ann)
+                     (subs line-str (:end-offset ann))
+                     (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
+                                                           (:end-offset ann))))]
+        (if (nil? next-ann)
+          (str acc prefix highlight suffix)
+          (recur ann-pairs
+                 (str acc prefix highlight suffix)
+                 (long (max (:begin-offset next-ann)
+                            (:end-offset ann)))))))))
+
+(defn highlight-text
   "TODO: overlapping phrase highlights are combined under one color, maybe solve it?"
   [line-str highlights options]
   (if (:with-score options)
     line-str
     (when (seq highlights)
-      (let [highlights (sort-by :begin-offset highlights)
-            highlight-fn (if (and (string? (:pre-tags options)) (string? (:post-tags options)))
-                           #(str (:pre-tags options) % (:post-tags options))
-                           ansi/red-text)]
-        (loop [[[ann next-ann] & ann-pairs] (partition 2 1 nil highlights)
-               acc ""
-               last-position 0]
-          (let [prefix (subs line-str last-position (max last-position (:begin-offset ann)))
-                highlight (let [text-to-highlight (subs line-str (:begin-offset ann) (:end-offset ann))]
-                            (if (< (:begin-offset ann) last-position)
-                              ; adjusting highlight text for overlap
-                              (highlight-fn (subs text-to-highlight (min (.length text-to-highlight)
-                                                                         (- last-position (:begin-offset ann)))))
-                              (highlight-fn text-to-highlight)))
-                suffix (if (nil? next-ann)
-                         (subs line-str (:end-offset ann))
-                         (subs line-str (:end-offset ann) (max (:begin-offset next-ann)
-                                                               (:end-offset ann))))]
-            (if (nil? next-ann)
-              (str acc prefix highlight suffix)
-              (recur ann-pairs
-                     (str acc prefix highlight suffix)
-                     (long (max (:begin-offset next-ann)
-                                (:end-offset ann)))))))))))
+      (if (:split options)
+        (highlight-line line-str highlights options)
+        (cutout-highlight line-str highlights options)))))
 
 (defn file-string [file line-number options]
   (if (and (:hyperlink options) file)
@@ -46,7 +72,7 @@
       (-> template
           (str/replace "{{file}}" (or (file-string (:file details) (:line-number details) options) ""))
           (str/replace "{{line-number}}" (str (:line-number details)))
-          (str/replace "{{highlighted-line}}" (highlight-line (:line details) highlights options))
+          (str/replace "{{highlighted-line}}" (highlight-text (:line details) highlights options))
           (str/replace "{{line}}" (:line details))
           (str/replace "{{score}}" (str (:score details)))))
     (if (:score details)
@@ -54,8 +80,8 @@
               (ansi/purple-text (or (file-string (:file details) (:line-number details) options) "*STDIN*"))
               (ansi/green-text (:line-number details))
               (ansi/purple-text (:score details))
-              (highlight-line (:line details) highlights options))
+              (highlight-text (:line details) highlights options))
       (format "%s:%s:%s"
               (ansi/purple-text (or (file-string (:file details) (:line-number details) options) "*STDIN*"))
               (ansi/green-text (:line-number details))
-              (highlight-line (:line details) highlights options)))))
+              (highlight-text (:line details) highlights options)))))

--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -4,6 +4,7 @@
             [lmgrep.fs :as fs]
             [lmgrep.lucene :as lucene]
             [lmgrep.analysis :as analysis]
+            [lmgrep.no-split :as no-split]
             [lmgrep.unordered :as unordered])
   (:import (java.io File)))
 
@@ -34,7 +35,9 @@
         highlighter-fn (lucene/highlighter questionnaire options custom-analyzers)
         file-paths-to-analyze (into (fs/get-files files-pattern options)
                                     (fs/filter-files files))]
-    (unordered/grep file-paths-to-analyze highlighter-fn options)))
+    (if (:split options)
+      (unordered/grep file-paths-to-analyze highlighter-fn options)
+      (no-split/grep file-paths-to-analyze highlighter-fn options))))
 
 (comment
   (lmgrep.grep/grep ["opt"] "**.md" nil {:format :edn})

--- a/src/lmgrep/matching.clj
+++ b/src/lmgrep/matching.clj
@@ -1,6 +1,7 @@
 (ns lmgrep.matching
   (:require [jsonista.core :as json]
-            [lmgrep.formatter :as formatter])
+            [lmgrep.formatter :as formatter]
+            [lmgrep.lucene])
   (:import (lmgrep.lucene LuceneMonitorMatcher)))
 
 (defn sum-score [highlights]

--- a/src/lmgrep/no_split.clj
+++ b/src/lmgrep/no_split.clj
@@ -1,0 +1,29 @@
+(ns lmgrep.no-split
+  (:require [lmgrep.matching :as matching])
+  (:import (java.nio.file Files Path)
+           (java.io File BufferedWriter PrintWriter)))
+
+(defn grep
+  [file-paths-to-analyze highlighter-fn options]
+  (when (empty? file-paths-to-analyze)
+    (.println System/err "Standard input is not supported!"))
+  (let [with-empty-lines (get options :with-empty-lines)
+        print-writer-buffer-size (get options :writer-buffer-size 8192)
+        ^PrintWriter writer (PrintWriter. (BufferedWriter. *out* print-writer-buffer-size)
+                                          ^Boolean (empty? file-paths-to-analyze))]
+    (doseq [^String path file-paths-to-analyze]
+      (let [^String content (Files/readString ^Path (.toPath (File. path)))
+            matcher-fn (matching/matcher-fn highlighter-fn path options)
+            out-str (matcher-fn 1 content)]
+        (if out-str
+          (.println writer out-str)
+          (when with-empty-lines
+            (.println writer)))))
+    (.flush writer)))
+
+(comment
+  (require '[lmgrep.lucene :as lucene])
+
+  (lmgrep.no-split/grep ["test/resources/test.txt"]
+                        (lucene/highlighter [{:query "dog"}] {} {})
+                        {:format :json}))

--- a/test/lmgrep/formatter_test.clj
+++ b/test/lmgrep/formatter_test.clj
@@ -1,0 +1,17 @@
+(ns lmgrep.formatter-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [lmgrep.formatter :as f]))
+
+(deftest no-split-formatting
+  (testing "multiline handling"
+    (let [input-text (slurp "test/resources/test.txt")
+          highlights [{:query "dog"
+                       :type  "QUERY",
+                       :dict-entry-id 601069600,
+                       :meta {},
+                       :begin-offset 40,
+                       :end-offset 43}]
+          options {}
+          cutout-highlights (f/cutout-highlight input-text highlights options)]
+      (is (= "jumps over the lazy \u001B[1;31mdog\u001B[0m Apache Lucene™ is a"
+             cutout-highlights)))))

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -81,7 +81,9 @@
 (deftest grepping-stdin-with-detailed-json-output
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "fox"
-        options {:format :json :with-details true}]
+        options {:format :json
+                 :with-details true
+                 :split true}]
     (is (= {:line-number 1
             :line        text-from-stdin
             :highlights  [{:type          "QUERY"
@@ -100,7 +102,10 @@
 (deftest grepping-stdin-with-detailed-json-output-with-score
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "fox"
-        options {:format :json :with-details true :with-score true}]
+        options {:format :json
+                 :with-details true
+                 :with-score true
+                 :split true}]
     (is (= {:highlights  [{:dict-entry-id "1044772177"
                            :meta          {}
                            :query         "fox"
@@ -119,7 +124,10 @@
 (deftest grepping-stdin-with-detailed-json-output-with-scored-highlights
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "fox"
-        options {:format :json :with-details true :with-scored-highlights true}]
+        options {:format :json
+                 :with-details true
+                 :with-scored-highlights true
+                 :split true}]
     (is (= {:highlights  [{:begin-offset  16
                            :dict-entry-id "1044772177"
                            :end-offset    19
@@ -140,7 +148,10 @@
   (testing "fuzzy matching"
     (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
           query "fxo~2"
-          options {:format :json :with-details true :with-scored-highlights true}]
+          options {:format :json
+                   :with-details true
+                   :with-scored-highlights true
+                   :split true}]
       (is (= {:highlights  [{:begin-offset  16
                              :dict-entry-id "1081731735"
                              :end-offset    19

--- a/test/lmgrep/lucene_test.clj
+++ b/test/lmgrep/lucene_test.clj
@@ -9,7 +9,7 @@
           highlighter-fn (lucene/highlighter [{:query query-string}])
           text "prefix text suffix"]
       (is (= (str "prefix " \ "[1;31mtext" \ "[0m suffix")
-             (formatter/highlight-line text (highlighter-fn text) {}))))))
+             (formatter/highlight-text text (highlighter-fn text) {}))))))
 
 (deftest highlighter-details
   (testing "simple case"

--- a/test/lmgrep/no_split_test.clj
+++ b/test/lmgrep/no_split_test.clj
@@ -1,0 +1,13 @@
+(ns lmgrep.no-split-test
+  (:require [clojure.test :refer [deftest is]]
+            [jsonista.core :as json]
+            [lmgrep.lucene :as lucene]
+            [lmgrep.no-split :as no-split]))
+
+(deftest one-file-at-a-time
+  (let [files ["test/resources/test.txt"]
+        highlighter-fn (lucene/highlighter [{:query "dog"}] {} {})]
+    (is (seq
+          (json/read-value
+            (with-out-str (no-split/grep files highlighter-fn {:format :json}))
+            json/keyword-keys-object-mapper)))))


### PR DESCRIPTION
The functionality was broken since reworked the concurrent processing 🤦 