### PR TITLE
Wrap Lucene Monitor into a Closeable protocol

### DIFF
--- a/src/lmgrep/grep.clj
+++ b/src/lmgrep/grep.clj
@@ -31,10 +31,10 @@
 (defn grep [lucene-query-strings files-pattern files options]
   (let [questionnaire (combine-questionnaire lucene-query-strings options)
         custom-analyzers (analysis/prepare-analyzers (get options :analyzers-file) options)
-        highlighter-fn (lucene/highlighter questionnaire options custom-analyzers)
         file-paths-to-analyze (into (fs/get-files files-pattern options)
                                     (fs/filter-files files))]
-    (unordered/grep file-paths-to-analyze highlighter-fn options)))
+    (with-open [highlighter (lucene/highlighter-obj questionnaire options custom-analyzers)]
+      (unordered/grep file-paths-to-analyze highlighter options))))
 
 (comment
   (lmgrep.grep/grep ["opt"] "**.md" nil {:format :edn})

--- a/src/lmgrep/lucene.clj
+++ b/src/lmgrep/lucene.clj
@@ -37,4 +37,4 @@
     (match highlighter text match-opts)))
 
 (comment
-  (dotimes [_ 10000] (highlight [{:query "text"}] {} "foo text bar" {})))
+  (highlight [{:query "text"}] {} "foo text bar" {}))

--- a/src/lmgrep/lucene.clj
+++ b/src/lmgrep/lucene.clj
@@ -5,21 +5,6 @@
   (:import (java.io Closeable)
            (org.apache.lucene.monitor Monitor)))
 
-(defn highlighter
-  ([questionnaire] (highlighter questionnaire {}))
-  ([questionnaire options] (highlighter questionnaire options {}))
-  ([questionnaire {:keys [type-name] :as options} custom-analyzers]
-   (let [default-type (if (s/blank? type-name) "QUERY" type-name)
-         {:keys [monitor field-names]} (monitor/setup questionnaire default-type options custom-analyzers)]
-     (fn
-       ([text] (matching/match-monitor text monitor field-names {}))
-       ([text opts] (matching/match-monitor text monitor field-names opts))))))
-
-(comment
-  (dotimes [_ 10000]
-    ((highlighter [{:query "text"}] {}) "foo text bar"))
-  ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true}))
-
 (defprotocol IMatcher
   (match [this text] [this text opts]))
 
@@ -33,13 +18,23 @@
   (close [_] (.close ^Monitor monitor)))
 
 (defn highlighter-obj
-  ([questionnaire] (highlighter-obj questionnaire {}))
-  ([questionnaire options] (highlighter-obj questionnaire options {}))
-  ([questionnaire {:keys [type-name] :as options} custom-analyzers]
+  (^LuceneMonitorMatcher [questionnaire] (highlighter-obj questionnaire {}))
+  (^LuceneMonitorMatcher [questionnaire options] (highlighter-obj questionnaire options {}))
+  (^LuceneMonitorMatcher [questionnaire {:keys [type-name] :as options} custom-analyzers]
    (let [default-type (if (s/blank? type-name) "QUERY" type-name)
          {:keys [monitor field-names]} (monitor/setup questionnaire default-type options custom-analyzers)]
      (->LuceneMonitorMatcher monitor field-names))))
 
 (comment
   (with-open [lm (highlighter-obj [{:query "text"}] {})]
-    (.match lm "foo text bar")))
+    (match lm "foo text bar")))
+
+(defn highlight
+  "Convenience function that creates a highlighter, matches the text,
+  closes the highlighter, returns matches."
+  [dictionary highlighter-opts text match-opts]
+  (with-open [highlighter (highlighter-obj dictionary highlighter-opts)]
+    (match highlighter text match-opts)))
+
+(comment
+  (dotimes [_ 10000] (highlight [{:query "text"}] {} "foo text bar" {})))

--- a/src/lmgrep/lucene.clj
+++ b/src/lmgrep/lucene.clj
@@ -15,6 +15,11 @@
        ([text] (matching/match-monitor text monitor field-names {}))
        ([text opts] (matching/match-monitor text monitor field-names opts))))))
 
+(comment
+  (dotimes [_ 10000]
+    ((highlighter [{:query "text"}] {}) "foo text bar"))
+  ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true}))
+
 (defprotocol IMatcher
   (match [this text] [this text opts]))
 
@@ -36,8 +41,5 @@
      (->LuceneMonitorMatcher monitor field-names))))
 
 (comment
-  ((highlighter [{:query "text"}] {}) "foo text bar")
-  ((highlighter [{:query "text bar"}]) "foo text bar one more time text with bar text" {:with-score true})
-
   (with-open [lm (highlighter-obj [{:query "text"}] {})]
     (.match lm "foo text bar")))

--- a/src/lmgrep/matching.clj
+++ b/src/lmgrep/matching.clj
@@ -1,37 +1,20 @@
 (ns lmgrep.matching
   (:require [jsonista.core :as json]
-            [lmgrep.formatter :as formatter])
+            [lmgrep.formatter :as formatter]
+            [lmgrep.lucene :as lucene])
   (:import (lmgrep.lucene LuceneMonitorMatcher)))
 
 (defn sum-score [highlights]
   (when-let [scores (seq (remove nil? (map :score highlights)))]
     (reduce + scores)))
 
-(defn matcher-fn [highlighter-fn file-path options]
+(defn matcher-fn [^LuceneMonitorMatcher highlighter-obj file-path options]
   (let [highlight-opts (select-keys options [:with-score :with-scored-highlights])
         with-details? (get options :with-details)
         format (get options :format)
         scored? (or (get options :with-score) (get options :with-scored-highlights))]
     (fn [line-nr line]
-      (when-let [highlights (seq (highlighter-fn line highlight-opts))]
-        (let [details (cond-> {:line-number line-nr
-                               :line        line}
-                              file-path (assoc :file file-path)
-                              (true? scored?) (assoc :score (sum-score highlights))
-                              (true? with-details?) (assoc :highlights highlights))]
-          (case format
-            :edn (pr-str details)
-            :json (json/write-value-as-string details)
-            :string (formatter/string-output highlights details options)
-            (formatter/string-output highlights details options)))))))
-
-(defn matcher-fn-2 [^LuceneMonitorMatcher highlighter-obj file-path options]
-  (let [highlight-opts (select-keys options [:with-score :with-scored-highlights])
-        with-details? (get options :with-details)
-        format (get options :format)
-        scored? (or (get options :with-score) (get options :with-scored-highlights))]
-    (fn [line-nr line]
-      (when-let [highlights (seq (.match highlighter-obj line highlight-opts))]
+      (when-let [highlights (seq (lucene/match highlighter-obj line highlight-opts))]
         (let [details (cond-> {:line-number line-nr
                                :line        line}
                               file-path (assoc :file file-path)

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -26,7 +26,7 @@
       (when (and query text)
         (with-open [^LuceneMonitorMatcher highlighter
                     (lucene/highlighter-obj [{:query query}] options custom-analyzers)]
-          ((matching/matcher-fn-2 highlighter nil options) line-nr text))))))
+          ((matching/matcher-fn highlighter nil options) line-nr text))))))
 
 (defn unordered [reader ^ExecutorService matcher-thread-pool-executor
                  ^PrintWriter writer ^ExecutorService writer-thread-pool-executor

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -51,7 +51,7 @@
                                            (.println writer)))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
-(defn grep [file-paths-to-analyze highlighter-fn options]
+(defn grep [file-paths-to-analyze highlighter options]
   (let [preserve-order? (get options :preserve-order true)
         reader-buffer-size (get options :reader-buffer-size 8192)
         print-writer-buffer-size (get options :writer-buffer-size 8192)
@@ -69,7 +69,7 @@
       (let [reader (if path
                      (BufferedReader. (FileReader. path) reader-buffer-size)
                      (BufferedReader. *in* reader-buffer-size))
-            matcher-fn (matching/matcher-fn highlighter-fn path options)]
+            matcher-fn (matching/matcher-fn highlighter path options)]
         (consume-fn reader
                     matcher-fn
                     matcher-thread-pool-executor

--- a/test/lmgrep/grep_test.clj
+++ b/test/lmgrep/grep_test.clj
@@ -8,7 +8,10 @@
   (let [file "test/resources/test.txt"
         query "fox"
         options {:preserve-order true
-                 :split true :pre-tags ">" :post-tags "<" :template "{{highlighted-line}}"}]
+                 :split          true
+                 :pre-tags       ">"
+                 :post-tags      "<"
+                 :template       "{{highlighted-line}}"}]
     (is (= "The quick brown >fox< jumps over the lazy dog"
            (str/trim
              (with-out-str
@@ -30,9 +33,9 @@
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "fox"
         options {:preserve-order false
-                 :split true
-                 :pre-tags ">" :post-tags "<"
-                 :template "{{highlighted-line}}"}]
+                 :split          true
+                 :pre-tags       ">" :post-tags "<"
+                 :template       "{{highlighted-line}}"}]
     (is (= "The quick brown >fox< jumps over the lazy dog"
            (with-in-str text-from-stdin
                         (str/trim
@@ -42,9 +45,9 @@
 (deftest grepping-ordered-vs-unordered
   (let [file "README.md"
         query "test"
-        options {:split          true
-                 :pre-tags       ">" :post-tags "<"
-                 :template       "{{line-number}}"}
+        options {:split    true
+                 :pre-tags ">" :post-tags "<"
+                 :template "{{line-number}}"}
         ordered-options (assoc options :preserve-order true)
         ordered-matched-lines (str/split-lines
                                 (str/trim
@@ -171,10 +174,10 @@
 (deftest grepping-multiple-queries-from-file
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         queries []
-        options {:split true
-                 :pre-tags ">"
-                 :post-tags "<"
-                 :template "{{highlighted-line}}"
+        options {:split        true
+                 :pre-tags     ">"
+                 :post-tags    "<"
+                 :template     "{{highlighted-line}}"
                  :queries-file "test/resources/queries.json"}]
     (is (= "The quick brown >fox< jumps over the lazy >dog<"
            (with-in-str text-from-stdin
@@ -186,10 +189,10 @@
   (testing "with classic query parser fails"
     (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
           queries []
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
                    :queries-file "test/resources/problematic-queries.json"}]
       (is (thrown? Exception
                    (with-in-str text-from-stdin
@@ -199,28 +202,28 @@
   (testing "with simple query parser it works"
     (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
           queries []
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
                    :query-parser "simple"
                    :queries-file "test/resources/problematic-queries.json"}]
       (is (= "The quick brown >fox< jumps over the lazy >dog<"
-                   (with-in-str text-from-stdin
-                                (str/trim
-                                  (with-out-str
-                                    (grep/grep queries nil nil options)))))))))
+             (with-in-str text-from-stdin
+                          (str/trim
+                            (with-out-str
+                              (grep/grep queries nil nil options)))))))))
 
 (deftest grepping-multiple-queries-from-file-options
   (testing "options text analysis is injected into dictionary entry if not present"
     (let [text-from-stdin (str/upper-case "The quick brown fox jumps over the lazy dog")
           queries []
-          options {:split           true
-                   :analysis {:token-filters []}
-                   :pre-tags        ">"
-                   :post-tags       "<"
-                   :template        "{{highlighted-line}}"
-                   :queries-file    "test/resources/queries.json"}]
+          options {:split        true
+                   :analysis     {:token-filters []}
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :queries-file "test/resources/queries.json"}]
       (is (= ""
              (with-in-str text-from-stdin
                           (str/trim
@@ -239,7 +242,7 @@
           options {:split        true
                    :format       :json
                    :with-details true
-                   :analysis {:token-filters [{:name "lowercase"}]}
+                   :analysis     {:token-filters [{:name "lowercase"}]}
                    :queries-file "test/resources/queries.json"}]
       (is (= {:highlights  [{:begin-offset  16
                              :dict-entry-id "1372536417"
@@ -309,11 +312,11 @@
 (deftest grepping-when-no-match-with-flag-to-println-empty-line
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "foo"
-        options {:split true
-                 :pre-tags ">"
-                 :post-tags "<"
+        options {:split            true
+                 :pre-tags         ">"
+                 :post-tags        "<"
                  :with-empty-lines true
-                 :template "{{highlighted-line}}"}]
+                 :template         "{{highlighted-line}}"}]
     (is (= "\n" (with-in-str text-from-stdin
                              (with-out-str
                                (grep/grep [query] nil nil options)))))))
@@ -335,11 +338,11 @@
 (deftest combination-of-flags-and-analysis-conf
   (let [text-from-stdin "The quick brown fox jumps over the lazy dog"
         query "jump"
-        options {:split true
-                 :pre-tags ">"
-                 :post-tags "<"
+        options {:split            true
+                 :pre-tags         ">"
+                 :post-tags        "<"
                  :with-empty-lines true
-                 :template "{{highlighted-line}}"}]
+                 :template         "{{highlighted-line}}"}]
 
     (testing "standard analyzer should produce no matches"
       (let [options (assoc options :analysis {:analyzer {:name "standard"}})]
@@ -357,7 +360,7 @@
 (deftest hyperlink-with-stdin
   (let [text-from-stdin "this will generate an exception"
         query "exception"
-        options {:split true
+        options {:split     true
                  :hyperlink true}]
     (testing "hyperlinking on stdin should be ignored"
       (let [options (assoc options :analysis {:analyzer {:name "standard"}})]
@@ -369,11 +372,11 @@
 (deftest grepping-with-simple-query-parser
   (let [text-from-stdin "john foo peters post"
         query "\"john peters\"~2"
-        options {:split true
+        options {:split        true
                  :query-parser "simple"
-                 :pre-tags ">"
-                 :post-tags "<"
-                 :template "{{highlighted-line}}"}]
+                 :pre-tags     ">"
+                 :post-tags    "<"
+                 :template     "{{highlighted-line}}"}]
     (testing "simple case"
       (is (= ">john foo peters< post"
              (with-in-str text-from-stdin
@@ -384,11 +387,11 @@
 (deftest grepping-with-standard-query-parser
   (let [text-from-stdin "john foo peters post"
         query "\"john peters\"~2"
-        options {:split true
+        options {:split        true
                  :query-parser "standard"
-                 :pre-tags ">"
-                 :post-tags "<"
-                 :template "{{highlighted-line}}"}]
+                 :pre-tags     ">"
+                 :post-tags    "<"
+                 :template     "{{highlighted-line}}"}]
     (testing "simple case"
       (is (= ">john foo peters< post"
              (with-in-str text-from-stdin
@@ -399,10 +402,10 @@
 (deftest grepping-with-complex-phrase-query-parser
   (let [text-from-stdin "john foo peters post"
         query "\"john peters\"~2"
-        options {:split true
-                 :pre-tags ">"
+        options {:split     true
+                 :pre-tags  ">"
                  :post-tags "<"
-                 :template "{{highlighted-line}}"}]
+                 :template  "{{highlighted-line}}"}]
     (testing "without complex phrase flag doesn't match"
       (is (= ">john foo peters< post"
              (with-in-str text-from-stdin
@@ -432,11 +435,11 @@
   (testing "basic query"
     (let [text-from-stdin "nike and adidas"
           query "2W(nike, adidas)"
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
-                   :analysis {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :analysis     {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
                    :query-parser "surround"}]
       (is (= ">nike< and >adidas<"
              (with-in-str text-from-stdin
@@ -461,11 +464,11 @@
   (testing "unordered"
     (let [text-from-stdin "adidas and nike"
           query "2N(nike, adidas)"
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
-                   :analysis {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :analysis     {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
                    :query-parser "surround"}]
       (is (= ">adidas< and >nike<"
              (with-in-str text-from-stdin
@@ -476,11 +479,11 @@
   (testing "fuzzy match"
     (let [text-from-stdin "adidas and nikon"
           query "2N(nik*, adidas)"
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
-                   :analysis {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :analysis     {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
                    :query-parser "surround"}]
       (is (= ">adidas< and >nikon<"
              (with-in-str text-from-stdin
@@ -489,11 +492,11 @@
                               (grep/grep [query] nil nil options)))))))
     (let [text-from-stdin "adibas and nikon"
           query "2N(nik*, adi?as)"
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
-                   :analysis {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :analysis     {:token-filters [{:name "lowercase"} {:name "asciifolding"}]}
                    :query-parser "surround"}]
       (is (= ">adibas< and >nikon<"
              (with-in-str text-from-stdin
@@ -504,13 +507,13 @@
   (testing "quoting"
     (let [text-from-stdin "adidas foos"
           query "OR(\"adidas foo\"*, nike)"                 ; `adidas foo` should be one term
-          options {:split true
-                   :pre-tags ">"
-                   :post-tags "<"
-                   :template "{{highlighted-line}}"
-                   :stem? false
-                   :analysis {:tokenizer {:name "keyword"}
-                              :token-filters [{:name "lowercase"} {:name "asciifolding"}]}
+          options {:split        true
+                   :pre-tags     ">"
+                   :post-tags    "<"
+                   :template     "{{highlighted-line}}"
+                   :stem?        false
+                   :analysis     {:tokenizer     {:name "keyword"}
+                                  :token-filters [{:name "lowercase"} {:name "asciifolding"}]}
                    :query-parser "surround"}]
       (is (= ">adidas foos<"
              (with-in-str text-from-stdin
@@ -521,7 +524,7 @@
 (deftest grepping-multiple-queries-from-file-with-query-parsers
   (let [text-from-stdin "john foo peterson post"
         queries []
-        options {:split true
+        options {:split        true
                  :format       :json
                  :with-details true
                  :queries-file "test/resources/queries-query-parsers.json"}]
@@ -550,7 +553,7 @@
   (testing "by default query parser allows loading wildcards"
     (let [file "test/resources/test.txt"
           query "*fox"
-          options {:split true :pre-tags ">" :post-tags "<"
+          options {:split    true :pre-tags ">" :post-tags "<"
                    :template "{{highlighted-line}}"}]
       (is (= "The quick brown >fox< jumps over the lazy dog"
              (str/trim
@@ -560,16 +563,16 @@
   (testing "explicitly declared :allow-leading-wildcard false causes exception"
     (let [file "test/resources/test.txt"
           query "*fox"
-          options {:split true
-                   :pre-tags ">" :post-tags "<"
-                   :template "{{highlighted-line}}"
+          options {:split             true
+                   :pre-tags          ">" :post-tags "<"
+                   :template          "{{highlighted-line}}"
                    :query-parser-conf {:allow-leading-wildcard false}}]
       (is (thrown? Exception (grep/grep [query] file nil options)))))
 
   (testing "explicitly declared :allow-leading-wildcard false causes exception in queries file"
     (let [file "test/resources/test.txt"
-          options {:split true
-                   :pre-tags ">" :post-tags "<"
-                   :template "{{highlighted-line}}"
+          options {:split        true
+                   :pre-tags     ">" :post-tags "<"
+                   :template     "{{highlighted-line}}"
                    :queries-file "test/resources/query-parser-conf.json"}]
       (is (thrown? Exception (grep/grep [] file nil options))))))

--- a/test/lmgrep/lucene_test.clj
+++ b/test/lmgrep/lucene_test.clj
@@ -3,17 +3,13 @@
             [lmgrep.formatter :as formatter]
             [lmgrep.lucene :as lucene]))
 
-(defn highlight [dictionary highlighter-opts text match-opts]
-  (with-open [highlighter (lucene/highlighter-obj dictionary highlighter-opts)]
-    (lucene/match highlighter text match-opts)))
-
 (deftest highlighting-test
   (testing "coloring the output"
     (let [query-string "text"
           text "prefix text suffix"
           dictionary [{:query query-string}]]
       (is (= (str "prefix " \ "[1;31mtext" \ "[0m suffix")
-             (formatter/highlight-line text (highlight dictionary {} text {}) {}))))))
+             (formatter/highlight-line text (lucene/highlight dictionary {} text {}) {}))))))
 
 (deftest highlighter-details
   (testing "simple case"
@@ -22,7 +18,7 @@
           dictionary [{:query query :id "0" :meta {:foo "bar"}}]]
       (is (= [{:query "text" :type "QUERY" :dict-entry-id "0"
                :meta  {"foo" "bar"} :begin-offset 4 :end-offset 8}]
-             (highlight dictionary {} text {}))))))
+             (lucene/highlight dictionary {} text {}))))))
 
 (deftest highlighter-with-presearcher
   (testing "presearching implementations should not change the output"
@@ -33,7 +29,7 @@
               dictionary [{:query query :id "0" :meta {:foo "bar"}}]]
           (is (= [{:query "text" :type "QUERY" :dict-entry-id "0"
                    :meta  {"foo" "bar"} :begin-offset 4 :end-offset 8}]
-                 (highlight dictionary {:presearcher presearcher} text {}))))))))
+                 (lucene/highlight dictionary {:presearcher presearcher} text {}))))))))
 
 (deftest word-delimiter-highlights
   (testing "word delimiter"
@@ -62,4 +58,4 @@
                :meta          {}
                :query         "best class"
                :type          "QUERY"}]
-             (highlight dictionary {} text {}))))))
+             (lucene/highlight dictionary {} text {}))))))


### PR DESCRIPTION
Prevents strange OOM when 8K+ monitors are created in a loop. During runtime it doesn't happen only during development in a REPL session.