### PR TITLE
Print operations namespace

### DIFF
--- a/src/lmgrep/cli/analysis_conf.clj
+++ b/src/lmgrep/cli/analysis_conf.clj
@@ -1,4 +1,5 @@
-(ns lmgrep.cli.analysis-conf)
+(ns lmgrep.cli.analysis-conf
+  (:require [lmgrep.print :as print]))
 
 (def analysis-keys #{:case-sensitive?
                      :ascii-fold?
@@ -8,7 +9,7 @@
                      :word-delimiter-graph-filter})
 
 (def default-text-analysis
-  {:tokenizer {:name "standard"}
+  {:tokenizer     {:name "standard"}
    :token-filters [{:name "lowercase"}
                    {:name "asciifolding"}
                    {:name "englishMinimalStem"}]})
@@ -16,39 +17,39 @@
 (def ^String stemmer
   "Creates a stemmer object given the stemmer keyword.
   Default stemmer is English."
-  {:arabic "arabicstem"
-   :armenian "armenianSnowballStem"
-   :basque "basqueSnowballStem"
-   :catalan "catalanSnowballStem"
-   :danish "danishSnowballStem"
-   :dutch "dutchSnowballStem"
-   :english "englishMinimalStem"
-   :estonian "basqueSnowballStem"
-   :finnish "finnishlightstem"
-   :french "frenchLightStem"
-   :german2 "germanlightstem"
-   :german "germanstem"
-   :hungarian "hungarianLightStem"
-   :irish "irishSnowballStem"
-   :italian "italianlightstem"
-   :kp "kpSnowballStem"
+  {:arabic     "arabicstem"
+   :armenian   "armenianSnowballStem"
+   :basque     "basqueSnowballStem"
+   :catalan    "catalanSnowballStem"
+   :danish     "danishSnowballStem"
+   :dutch      "dutchSnowballStem"
+   :english    "englishMinimalStem"
+   :estonian   "basqueSnowballStem"
+   :finnish    "finnishlightstem"
+   :french     "frenchLightStem"
+   :german2    "germanlightstem"
+   :german     "germanstem"
+   :hungarian  "hungarianLightStem"
+   :irish      "irishSnowballStem"
+   :italian    "italianlightstem"
+   :kp         "kpSnowballStem"
    :lithuanian "lithuanianSnowballStem"
-   :lovins "lovinsSnowballStem"
-   :norwegian "norwegianminimalstem"
-   :porter "porterstem"
+   :lovins     "lovinsSnowballStem"
+   :norwegian  "norwegianminimalstem"
+   :porter     "porterstem"
    :portuguese "portugueselightstem"
-   :romanian "romanianSnowballStem"
-   :russian "russianlightstem"
-   :spanish "spanishlightstem"
-   :swedish "swedishlightstem"
-   :turkish "turkishSnowballStem"})
+   :romanian   "romanianSnowballStem"
+   :russian    "russianlightstem"
+   :spanish    "spanishlightstem"
+   :swedish    "swedishlightstem"
+   :turkish    "turkishSnowballStem"})
 
 (def tokenizer
-  {:keyword {:name "keyword"}
-   :letter {:name "letter"}
-   :standard {:name "standard"}
+  {:keyword            {:name "keyword"}
+   :letter             {:name "letter"}
+   :standard           {:name "standard"}
    :unicode-whitespace {:name "whitespace" :args {:rule "unicode"}}
-   :whitespace {:name "whitespace" :args {:rule "java"}}})
+   :whitespace         {:name "whitespace" :args {:rule "java"}}})
 
 (defn wdgf->token-filter-args
   "wdgf stands for Word Delimiter Graph Filter
@@ -84,8 +85,8 @@
                              (or (get stemmer stemmer-kw)
                                  (do
                                    (when stemmer-kw
-                                     (.println System/err
-                                               (format "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw)))
+                                     (print/to-err
+                                       (format "Stemmer '%s' not found! EnglishStemmer is used." stemmer-kw)))
                                    "englishMinimalStem")))})))
            (pos-int? (get flags :word-delimiter-graph-filter))
            (cons {:name "worddelimitergraph"
@@ -97,8 +98,9 @@
                         (or (get tokenizer tokenizer-kw)
                             (do
                               (when tokenizer-kw
-                                (.println System/err
-                                          (format "Tokenizer '%s' not found. StandardTokenizer is used." tokenizer-kw)))
+                                (print/to-err
+                                  (format "Tokenizer '%s' not found. StandardTokenizer is used."
+                                          tokenizer-kw)))
                               {:name "standard"})))
                       (get acm :tokenizer))
         token-filters (override-token-filters (get acm :token-filters) flags)]

--- a/src/lmgrep/core.clj
+++ b/src/lmgrep/core.clj
@@ -7,6 +7,7 @@
             [lmgrep.grep :as grep]
             [lmgrep.only-analyze :as analyze]
             [lmgrep.predefined-analyzers :as predefined]
+            [lmgrep.print :as print]
             [lmgrep.streamed :as streamed])
   (:gen-class))
 
@@ -61,7 +62,7 @@
               (grep/grep [lucene-query] file-pattern files options))))))
     (catch Exception e
       (when (System/getenv "DEBUG_MODE")
-        (.printStackTrace e))
-      (.println System/err (.getMessage e))
+        (print/throwable e))
+      (print/to-err (.getMessage e))
       (System/exit 1)))
   (System/exit 0))

--- a/src/lmgrep/fs.clj
+++ b/src/lmgrep/fs.clj
@@ -2,7 +2,8 @@
   (:require [clojure.java.io :as io]
             [clojure.java.shell :as sh]
             [clojure.string :as str]
-            [babashka.fs :as bfs])
+            [babashka.fs :as bfs]
+            [lmgrep.print :as print])
   (:import (java.nio.file FileSystems Path Files LinkOption)
            (java.io File IOException)))
 
@@ -113,7 +114,7 @@
         :visit-file-failed (if handle-error
                              (fn [path ^IOException exception]
                                (when (System/getenv "DEBUG_MODE")
-                                 (.println System/err (format "Visiting %s failed: %s" path (type exception))))
+                                 (print/to-err (format "Visiting %s failed: %s" path (type exception))))
                                :skip-subtree)
                              nil)})
      (let [results (persistent! @results)

--- a/src/lmgrep/lucene/analyzer.clj
+++ b/src/lmgrep/lucene/analyzer.clj
@@ -1,5 +1,6 @@
 (ns lmgrep.lucene.analyzer
   (:require [clojure.string :as str]
+            [lmgrep.print :as print]
             [lucene.custom.analyzer :as ca])
   (:import (org.apache.lucene.analysis Analyzer)))
 
@@ -54,5 +55,5 @@
                   token-filter-name->class))
      (catch Exception e
        (when (System/getenv "DEBUG_MODE")
-         (.printStackTrace e))
+         (print/throwable e))
        (throw e)))))

--- a/src/lmgrep/lucene/dictionary.clj
+++ b/src/lmgrep/lucene/dictionary.clj
@@ -2,7 +2,8 @@
   (:require [jsonista.core :as json]
             [lucene.custom.query :as q]
             [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.field-name :as field-name])
+            [lmgrep.lucene.field-name :as field-name]
+            [lmgrep.print :as print])
   (:import (org.apache.lucene.queryparser.classic ParseException)
            (org.apache.lucene.monitor MonitorQuery)
            (org.apache.lucene.search Query)
@@ -42,13 +43,13 @@
                          DEFAULT_FIELD_NAME_KEY default-field-name)))
       (catch ParseException e
         (when (System/getenv "DEBUG_MODE")
-          (.println System/err (format "Failed to parse query: '%s' with exception '%s'" mq e))
-          (.printStackTrace e))
+          (print/to-err (format "Failed to parse query: '%s' with exception '%s'" mq e))
+          (print/throwable e))
         (throw e))
       (catch Exception e
         (when (System/getenv "DEBUG_MODE")
-          (.println System/err (format "Failed create query: '%s' with '%s'" mq e))
-          (.printStackTrace e))
+          (print/to-err (format "Failed create query: '%s' with '%s'" mq e))
+          (print/throwable e))
         (throw e)))))
 
 (defn in-memory-query-constructor [custom-analyzers]
@@ -62,13 +63,13 @@
                        (prepare-meta meta)))
       (catch ParseException e
         (when (System/getenv "DEBUG_MODE")
-          (.println System/err (format "Failed to parse query: '%s' with exception '%s'" mq e))
-          (.printStackTrace e))
+          (print/to-err (format "Failed to parse query: '%s' with exception '%s'" mq e))
+          (print/throwable e))
         (throw e))
       (catch Exception e
         (when (System/getenv "DEBUG_MODE")
-          (.println System/err (format "Failed create query: '%s' with '%s'" mq e))
-          (.printStackTrace e))
+          (print/to-err (format "Failed create query: '%s' with '%s'" mq e))
+          (print/throwable e))
         (throw e)))))
 
 (defn stable-id [m]

--- a/src/lmgrep/lucene/monitor.clj
+++ b/src/lmgrep/lucene/monitor.clj
@@ -4,7 +4,8 @@
             [jsonista.core :as json]
             [lucene.custom.query :as query]
             [lmgrep.lucene.analyzer :as analyzer]
-            [lmgrep.lucene.dictionary :as dictionary])
+            [lmgrep.lucene.dictionary :as dictionary]
+            [lmgrep.print :as print])
   (:import (org.apache.lucene.monitor MonitorConfiguration Monitor MonitorQuerySerializer Presearcher TermFilteredPresearcher MultipassTermFilteredPresearcher)
            (org.apache.lucene.analysis.miscellaneous PerFieldAnalyzerWrapper)
            (java.util ArrayList)
@@ -96,7 +97,7 @@
       (catch Exception e
         (when (System/getenv "DEBUG_MODE")
           (.printStackTrace e))
-        (.println System/err (format "Failed to register query %s with exception '%s'" mq (.getMessage e)))))))
+        (print/to-err (format "Failed to register query %s with exception '%s'" mq (.getMessage e)))))))
 
 (defn register-queries [^Monitor monitor monitor-queries]
   (try
@@ -104,7 +105,7 @@
     (catch Exception e
       (when (System/getenv "DEBUG_MODE")
         (.printStackTrace e))
-      (.println System/err (format "Failed to register queries with exception '%s'" (.getMessage e)))
+      (print/to-err (format "Failed to register queries with exception '%s'" (.getMessage e)))
       (defer-to-one-by-one-registration monitor monitor-queries))))
 
 (defn setup

--- a/src/lmgrep/lucene/monitor.clj
+++ b/src/lmgrep/lucene/monitor.clj
@@ -96,7 +96,7 @@
       (.register monitor (doto (ArrayList.) (.add mq)))
       (catch Exception e
         (when (System/getenv "DEBUG_MODE")
-          (.printStackTrace e))
+          (print/throwable e))
         (print/to-err (format "Failed to register query %s with exception '%s'" mq (.getMessage e)))))))
 
 (defn register-queries [^Monitor monitor monitor-queries]
@@ -104,7 +104,7 @@
     (.register monitor ^Iterable monitor-queries)
     (catch Exception e
       (when (System/getenv "DEBUG_MODE")
-        (.printStackTrace e))
+        (print/throwable e))
       (print/to-err (format "Failed to register queries with exception '%s'" (.getMessage e)))
       (defer-to-one-by-one-registration monitor monitor-queries))))
 

--- a/src/lmgrep/only_analyze.clj
+++ b/src/lmgrep/only_analyze.clj
@@ -3,6 +3,7 @@
             [lmgrep.analysis :as analysis]
             [lmgrep.concurrent :as c]
             [lmgrep.fs :as fs]
+            [lmgrep.print :as print]
             [lmgrep.lucene.analyzer :as analyzer]
             [lucene.custom.text-analysis :as text-analysis])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
@@ -17,7 +18,7 @@
       (if (nil? line)
         (.flush writer)
         (do
-          (.println writer (text-analysis/text->graph line analyzer))
+          (print/to-writer writer (text-analysis/text->graph line analyzer))
           (recur (.readLine rdr)))))))
 
 (defn graph [files-to-analyze writer analyzer options]
@@ -45,7 +46,7 @@
                               (let [out-str (json/write-value-as-string
                                               (analysis-fn line analyzer))]
                                 (.execute writer-thread-pool-executor
-                                          ^Runnable (fn [] (.println writer out-str))))))
+                                          ^Runnable (fn [] (print/to-writer writer out-str))))))
         (recur (.readLine rdr))))))
 
 (defn ordered-analysis
@@ -60,7 +61,7 @@
                                      (json/write-value-as-string
                                        (analysis-fn line analyzer))))]
           (.execute writer-thread-pool-executor
-                    ^Runnable (fn [] (.println writer (.get f)))))
+                    ^Runnable (fn [] (print/to-writer writer (.get f)))))
         (recur (.readLine rdr))))))
 
 (defn execute-analysis [files-to-analyze ^PrintWriter writer analyzer options]

--- a/src/lmgrep/print.clj
+++ b/src/lmgrep/print.clj
@@ -1,4 +1,5 @@
 (ns lmgrep.print
+  (:require [clojure.stacktrace :as cst])
   (:import (java.io PrintWriter)))
 
 (defn to-err [^String s]
@@ -9,3 +10,6 @@
    (.println writer))
   ([^PrintWriter writer ^String s]
    (.println writer s)))
+
+(defn throwable [^Throwable t]
+  (cst/print-stack-trace t))

--- a/src/lmgrep/print.clj
+++ b/src/lmgrep/print.clj
@@ -1,0 +1,11 @@
+(ns lmgrep.print
+  (:import (java.io PrintWriter)))
+
+(defn to-err [^String s]
+  (.println System/err s))
+
+(defn to-writer
+  ([^PrintWriter writer]
+   (.println writer))
+  ([^PrintWriter writer ^String s]
+   (.println writer s)))

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -1,5 +1,6 @@
 (ns lmgrep.streamed
   (:require [jsonista.core :as json]
+            [lmgrep.io :as io]
             [lmgrep.lucene :as lucene]
             [lmgrep.analysis :as analysis]
             [lmgrep.matching :as matching]
@@ -16,7 +17,7 @@
     (catch Exception e
       (when (Boolean/parseBoolean (System/getenv "DEBUG_MODE"))
         (.printStackTrace e))
-      (.println System/err (.getMessage e)))))
+      (io/println-to-err (.getMessage e)))))
 
 (defn wrapped-matcher-fn [custom-analyzers options]
   (fn [^long line-nr ^String line]
@@ -40,10 +41,10 @@
                     ^Runnable (fn []
                                 (if-let [out-str (matcher-fn line-nr line)]
                                   (.execute writer-thread-pool-executor
-                                            ^Runnable (fn [] (.println writer out-str)))
+                                            ^Runnable (fn [] (io/print-to-writer writer out-str)))
                                   (when with-empty-lines
                                     (.execute writer-thread-pool-executor
-                                              ^Runnable (fn [] (.println writer)))))))
+                                              ^Runnable (fn [] (io/print-to-writer writer)))))))
           (recur (.readLine rdr) (inc line-nr)))))))
 
 (defn ordered [reader ^ExecutorService matcher-thread-pool-executor
@@ -60,9 +61,9 @@
                       ^Runnable (fn []
                                   (let [^String out-str (.get f)]
                                     (if out-str
-                                      (.println writer out-str)
+                                      (io/print-to-writer writer out-str)
                                       (when with-empty-lines
-                                        (.println writer)))))))
+                                        (io/print-to-writer writer)))))))
           (recur (.readLine rdr) (inc line-nr)))))))
 
 (defn grep

--- a/src/lmgrep/streamed.clj
+++ b/src/lmgrep/streamed.clj
@@ -16,7 +16,7 @@
     (json/read-value json-string)
     (catch Exception e
       (when (Boolean/parseBoolean (System/getenv "DEBUG_MODE"))
-        (.printStackTrace e))
+        (print/throwable e))
       (print/to-err (.getMessage e)))))
 
 (defn wrapped-matcher-fn [custom-analyzers options]

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -1,6 +1,6 @@
 (ns lmgrep.unordered
   (:require [lmgrep.concurrent :as c]
-            [lmgrep.io :as io]
+            [lmgrep.print :as print]
             [lmgrep.matching :as matching])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
            (java.util.concurrent ExecutorService)))
@@ -24,10 +24,10 @@
                               (let [^String out-str (matcher-fn line-nr line)]
                                 (if out-str
                                   (.execute writer-thread-pool-executor
-                                            ^Runnable (fn [] (io/print-to-writer writer out-str)))
+                                            ^Runnable (fn [] (print/to-writer writer out-str)))
                                   (when with-empty-lines
                                     (.execute writer-thread-pool-executor
-                                              ^Runnable (fn [] (io/print-to-writer writer))))))))
+                                              ^Runnable (fn [] (print/to-writer writer))))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn ordered-consume-reader
@@ -47,9 +47,9 @@
           (.execute writer-thread-pool-executor
                     ^Runnable (fn [] (let [out-str (.get f)]
                                        (if out-str
-                                         (io/print-to-writer writer out-str)
+                                         (print/to-writer writer out-str)
                                          (when with-empty-lines
-                                           (io/print-to-writer writer)))))))
+                                           (print/to-writer writer)))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn grep [file-paths-to-analyze highlighter options]

--- a/src/lmgrep/unordered.clj
+++ b/src/lmgrep/unordered.clj
@@ -1,5 +1,6 @@
 (ns lmgrep.unordered
   (:require [lmgrep.concurrent :as c]
+            [lmgrep.io :as io]
             [lmgrep.matching :as matching])
   (:import (java.io BufferedReader PrintWriter BufferedWriter FileReader)
            (java.util.concurrent ExecutorService)))
@@ -23,10 +24,10 @@
                               (let [^String out-str (matcher-fn line-nr line)]
                                 (if out-str
                                   (.execute writer-thread-pool-executor
-                                            ^Runnable (fn [] (.println writer out-str)))
+                                            ^Runnable (fn [] (io/print-to-writer writer out-str)))
                                   (when with-empty-lines
                                     (.execute writer-thread-pool-executor
-                                              ^Runnable (fn [] (.println writer))))))))
+                                              ^Runnable (fn [] (io/print-to-writer writer))))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn ordered-consume-reader
@@ -46,9 +47,9 @@
           (.execute writer-thread-pool-executor
                     ^Runnable (fn [] (let [out-str (.get f)]
                                        (if out-str
-                                         (.println writer out-str)
+                                         (io/print-to-writer writer out-str)
                                          (when with-empty-lines
-                                           (.println writer)))))))
+                                           (io/print-to-writer writer)))))))
         (recur (.readLine rdr) (inc line-nr))))))
 
 (defn grep [file-paths-to-analyze highlighter options]

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [jsonista.core :as json]
+            [lmgrep.print]
             [lmgrep.streamed :as streamed]))
 
 (deftest streamed-processing

--- a/test/lmgrep/streamed_test.clj
+++ b/test/lmgrep/streamed_test.clj
@@ -90,59 +90,61 @@
                             (with-out-str
                               (streamed/grep options))))))))
 
-  (doseq [options [{:preserve-order true
-                    :query-parser   "simple"
-                    :split          true}
+  (with-redefs [lmgrep.print/to-err (fn no-op [& _])
+                lmgrep.print/throwable (fn no-op [& _])]
+    (doseq [options [{:preserve-order true
+                      :query-parser   "simple"
+                      :split          true}
 
-                   {:preserve-order false
-                    :query-parser   "simple"
-                    :split          true}]]
+                     {:preserve-order false
+                      :query-parser   "simple"
+                      :split          true}]]
 
-    (testing "JSON that doesn't contain the text"
-      (let [text-from-stdin "{\"query\": \"AND nike~\"}"]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))
+      (testing "JSON that doesn't contain the text"
+        (let [text-from-stdin "{\"query\": \"AND nike~\"}"]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options)))))))
 
 
-    (testing "JSON that doesn't contain query"
-      (let [text-from-stdin "{\"text\": \"I am selling nikee\"}"]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))
+      (testing "JSON that doesn't contain query"
+        (let [text-from-stdin "{\"text\": \"I am selling nikee\"}"]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options)))))))
 
-    (testing "JSON that doesn't contain neither query nor text"
-      (let [text-from-stdin "{}"]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))
+      (testing "JSON that doesn't contain neither query nor text"
+        (let [text-from-stdin "{}"]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options)))))))
 
-    (testing "invalid JSON"
-      (let [text-from-stdin "{\"query\": \"AND nike~\", \"text\": \"I am selling nikee\""]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))
+      (testing "invalid JSON"
+        (let [text-from-stdin "{\"query\": \"AND nike~\", \"text\": \"I am selling nikee\""]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options)))))))
 
-    (testing "when query and text are empty strings"
-      (let [text-from-stdin "{\"query\": \"\", \"text\": \"\"}"]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))
+      (testing "when query and text are empty strings"
+        (let [text-from-stdin "{\"query\": \"\", \"text\": \"\"}"]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options)))))))
 
-    (testing "when query and text are nils"
-      (let [text-from-stdin "{\"query\": null, \"text\": null}"]
-        (is (empty?
-              (with-in-str
-                text-from-stdin
-                (with-out-str
-                  (streamed/grep options)))))))))
+      (testing "when query and text are nils"
+        (let [text-from-stdin "{\"query\": null, \"text\": null}"]
+          (is (empty?
+                (with-in-str
+                  text-from-stdin
+                  (with-out-str
+                    (streamed/grep options))))))))))


### PR DESCRIPTION
To goal is to get rid of the stack traces in the tests that expects exceptions to be thrown.